### PR TITLE
Add cleanup-media function

### DIFF
--- a/server/src/functions/supabase/config.toml
+++ b/server/src/functions/supabase/config.toml
@@ -9,3 +9,9 @@ entrypoint = "./functions/send-otp/index.ts"
 # Specifies static files to be bundled with the function. Supports glob patterns.
 # For example, if you want to serve static HTML pages in your function:
 # static_files = [ "./functions/send-otp/*.html" ]
+
+[functions.cleanup-media]
+enabled = true
+verify_jwt = false
+import_map = "./functions/cleanup-media/deno.json"
+entrypoint = "./functions/cleanup-media/index.ts"

--- a/server/src/functions/supabase/functions/cleanup-media/deno.json
+++ b/server/src/functions/supabase/functions/cleanup-media/deno.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "@supabase/supabase-js": "npm:@supabase/supabase-js@2.49.4"
+  }
+}

--- a/server/src/functions/supabase/functions/cleanup-media/index.ts
+++ b/server/src/functions/supabase/functions/cleanup-media/index.ts
@@ -1,0 +1,77 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "npm:@supabase/supabase-js";
+
+const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+const supabase = createClient(supabaseUrl, supabaseKey, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});
+
+const buckets = (Deno.env.get("CLEANUP_BUCKETS") ?? "").split(",").map(b => b.trim()).filter(Boolean);
+
+function joinPath(...parts: string[]) {
+  return parts.filter(Boolean).join("/");
+}
+
+async function listAllFiles(bucket: string, prefix = ""): Promise<string[]> {
+  const { data, error } = await supabase.storage.from(bucket).list(prefix, { limit: 1000 });
+  if (error) throw new Error(error.message);
+
+  const files: string[] = [];
+  for (const item of data ?? []) {
+    if (item.metadata === null) {
+      const nestedPrefix = joinPath(prefix, item.name);
+      const nested = await listAllFiles(bucket, nestedPrefix);
+      files.push(...nested);
+    } else {
+      files.push(joinPath(prefix, item.name));
+    }
+  }
+
+  return files;
+}
+
+async function cleanupBucket(bucket: string) {
+  const filePaths = await listAllFiles(bucket);
+  const existing = new Set(filePaths);
+
+  const { data, error } = await supabase
+    .from("Media")
+    .select("id, url")
+    .eq("storage->>bucket", bucket);
+
+  if (error) throw new Error(error.message);
+
+  const idsToDelete: string[] = [];
+  for (const row of data ?? []) {
+    if (!existing.has(row.url)) {
+      idsToDelete.push(row.id);
+    }
+  }
+
+  if (idsToDelete.length > 0) {
+    const { error: delError } = await supabase.from("Media").delete().in("id", idsToDelete);
+    if (delError) throw new Error(delError.message);
+  }
+
+  return idsToDelete.length;
+}
+
+Deno.serve(async () => {
+  try {
+    const results: Record<string, number> = {};
+    for (const bucket of buckets) {
+      const count = await cleanupBucket(bucket);
+      results[bucket] = count;
+    }
+    return new Response(JSON.stringify({ deleted: results }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: err.message }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- implement a Supabase edge function `cleanup-media` for scheduled cleanup
- list all files in configured buckets and remove Media rows without corresponding files
- configure the new function in `config.toml`

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68495bc4b3f8832bbda45bbfb9cc5729