### PR TITLE
Add count to pagination

### DIFF
--- a/client/definitions/types/index.ts
+++ b/client/definitions/types/index.ts
@@ -155,6 +155,7 @@ export interface IPaginationParams {
   page: number;
   next: string | null;
   hasNext?: boolean;
+  total?: number;
   sortBy: "createdAt" | "updatedAt";
   sortOrder: "asc" | "desc";
   startDate?: Date;

--- a/server/src/definitions/types/index.ts
+++ b/server/src/definitions/types/index.ts
@@ -159,6 +159,7 @@ export interface IPaginationParams {
   page: number;
   next: string | null;
   hasNext?: boolean;
+  total?: number;
   sortBy: "createdAt" | "updatedAt";
   sortOrder: "asc" | "desc";
   startDate?: Date;

--- a/server/src/features/Base.ts
+++ b/server/src/features/Base.ts
@@ -28,7 +28,9 @@ class Base<T extends Record<string, any>> {
   ): Promise<{
     data?: {
       items: T[];
-      pagination: Omit<IPaginationParams, "sortBy" | "sortOrder">;
+      pagination: Omit<IPaginationParams, "sortBy" | "sortOrder"> & {
+        total: number;
+      };
     };
     error: any;
   }> {
@@ -43,7 +45,7 @@ class Base<T extends Record<string, any>> {
 
     const from = (_pagination.page - 1) * _pagination.limit;
 
-    const { data, error } = await this._supabaseService.querySupabase<T>({
+    const { data, error, count } = await this._supabaseService.querySupabase<T>({
       table: this.tableName,
       modifyQuery: (qb: any) => {
         if (_pagination?.sortOrder && _pagination?.sortBy) {
@@ -73,6 +75,7 @@ class Base<T extends Record<string, any>> {
         return qb;
       },
       ...args,
+      count: "exact",
     });
 
     if (error) throw new Error(error.message);
@@ -85,6 +88,7 @@ class Base<T extends Record<string, any>> {
           ? (data as T[])[_pagination.limit - 1]?.createdAt
           : null,
       hasNext: data?.length > _pagination.limit,
+      total: count || 0,
     };
 
     if (_pagination.next) {

--- a/server/src/supabase/index.ts
+++ b/server/src/supabase/index.ts
@@ -61,6 +61,7 @@ class SupabaseService {
     query,
     select = "*",
     modifyQuery,
+    count,
   }: {
     table: string;
     query?: QueryFilter[];
@@ -68,10 +69,18 @@ class SupabaseService {
     modifyQuery?: (
       qb: PostgrestFilterBuilder<any, T, T[]>
     ) => PostgrestFilterBuilder<any, T, T[]> | PostgrestBuilder<T | T[] | null>;
-  }): Promise<{ data: T | T[] | null; error: PostgrestError | null }> {
+    count?: "exact" | "planned" | "estimated";
+  }): Promise<{
+    data: T | T[] | null;
+    error: PostgrestError | null;
+    count: number | null;
+  }> {
     let queryBuilder = this.supabaseClient
       .from(table)
-      .select(select) as PostgrestFilterBuilder<any, T, T[]>;
+      .select(select, count ? { count } : undefined) as PostgrestFilterBuilder<
+      any,
+      T,
+      T[]>;
 
     if (query && query.length > 0) {
       query.forEach((filter) => {


### PR DESCRIPTION
## Summary
- support row counts in `querySupabase`
- expose total count from `Base.getAll`
- update pagination types for server and client

## Testing
- `pre-commit` *(fails: cannot run due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68494e0eb84c832b991b741591ccd9cc