### PR TITLE
Implement client-side compression utilities

### DIFF
--- a/client/common/api/media.action.ts
+++ b/client/common/api/media.action.ts
@@ -1,6 +1,7 @@
 import { Platform } from "react-native";
 import axiosClient from "./base";
 import { base64ToBlob, uriToBlob, compressFile } from "@/utils";
+import { MEDIA_BUCKET_CONFIG } from "@/constants/media";
 import axios from "axios";
 
 export const getSignedUrlForUpload = async (body: Record<string, any>) => {
@@ -31,4 +32,63 @@ export const getSignedUrlForUpload = async (body: Record<string, any>) => {
   }
 
   return row;
+};
+
+export interface PickerAsset {
+  uri: string;
+  mimeType?: string | null;
+  fileName: string;
+  fileSize: number;
+  type?: string;
+}
+
+export const uploadPickerAsset = async (
+  asset: PickerAsset,
+  options: { bucket: string; compressionPercentage: number } & Record<string, any>
+) => {
+  const { bucket, compressionPercentage, ...rest } = options;
+  const config = MEDIA_BUCKET_CONFIG[bucket];
+  if (!config) throw new Error("Invalid bucket");
+
+  const { uri, mimeType, fileName, fileSize, type } = asset;
+
+  const compressed = await compressFile(uri, { mimeType: mimeType || undefined, percentage: compressionPercentage });
+  const newSize = compressed.size ?? fileSize;
+
+  if (newSize > config.maxSize) {
+    throw new Error("File size exceeds bucket limit");
+  }
+
+  const response = await axiosClient.post("/media/get-signed-upload-url", {
+    path: fileName,
+    bucket,
+    mimeType,
+    size: newSize,
+    name: fileName,
+    type,
+    ...rest,
+  });
+
+  const { data } = response.data;
+  const { row, signedUrl } = data;
+
+  const isWebPlatform = Platform.OS === "web";
+  let file: Blob | null = null;
+  if (isWebPlatform) {
+    file = compressed.blob ?? base64ToBlob(compressed.uri);
+  } else {
+    file = await uriToBlob(compressed.uri);
+  }
+
+  const uploadResponse = await axios.put(signedUrl, file, {
+    headers: {
+      "Content-Type": file.type,
+    },
+  });
+
+  if (uploadResponse.status !== 200) {
+    throw new Error("Failed to upload file");
+  }
+
+  return { ...row, size: newSize };
 };

--- a/client/constants/media.ts
+++ b/client/constants/media.ts
@@ -1,0 +1,11 @@
+export const MEDIA_PROFILES_BUCKET_NAME = "avatars";
+export const MEDIA_FILE_BUCKET_NAME = "event-files";
+
+export const MEDIA_BUCKET_CONFIG: Record<string, { maxSize: number }> = {
+  [MEDIA_FILE_BUCKET_NAME]: {
+    maxSize: 1024 * 1024 * 20, // 20MB
+  },
+  [MEDIA_PROFILES_BUCKET_NAME]: {
+    maxSize: 1024 * 1024 * 2, // 2MB
+  },
+};

--- a/client/utils/compression.ts
+++ b/client/utils/compression.ts
@@ -1,48 +1,93 @@
 import { Platform } from "react-native";
 
+async function compressVideoWeb(blob: Blob, targetSize: number): Promise<Blob> {
+  const url = URL.createObjectURL(blob);
+  const video = document.createElement("video");
+  video.src = url;
+  video.muted = true;
+  await new Promise((res) => video.addEventListener("loadedmetadata", res, { once: true }));
+  const bitsPerSecond = video.duration ? (targetSize * 8) / video.duration : undefined;
+  const stream = (video as any).captureStream();
+  const chunks: BlobPart[] = [];
+  const recorder = new MediaRecorder(stream, { mimeType: "video/webm", videoBitsPerSecond: bitsPerSecond });
+  recorder.ondataavailable = (e) => e.data.size && chunks.push(e.data);
+  const stopPromise = new Promise<Blob>((resolve) => {
+    recorder.onstop = () => resolve(new Blob(chunks, { type: "video/webm" }));
+  });
+  recorder.start();
+  video.play();
+  await new Promise((res) => video.addEventListener("ended", res, { once: true }));
+  recorder.stop();
+  const result = await stopPromise;
+  URL.revokeObjectURL(url);
+  return result;
+}
+
 export interface CompressResult {
   uri: string;
   blob?: Blob;
+  size?: number;
 }
 
 export interface CompressOptions {
   mimeType?: string;
+  percentage?: number; // desired size percentage of original file
 }
 
 export async function compressFile(uri: string, options: CompressOptions = {}): Promise<CompressResult> {
-  const { mimeType } = options;
+  const { mimeType, percentage = 100 } = options;
   const isImage = mimeType?.startsWith("image");
   const isVideo = mimeType?.startsWith("video");
-  if (!isImage && !isVideo) return { uri };
+  if (!isImage && !isVideo) {
+    const blob = Platform.OS === "web" ? await fetch(uri).then((r) => r.blob()) : undefined;
+    return { uri, blob, size: blob?.size };
+  }
 
   if (isImage) {
     if (Platform.OS === "web") {
       const { default: imageCompression } = await import("browser-image-compression");
       const blob = await fetch(uri).then((r) => r.blob());
+      const maxSizeMB = (blob.size / 1024 / 1024) * (percentage / 100);
       const compressed = await imageCompression(blob, {
-        maxSizeMB: 1,
+        maxSizeMB,
         maxWidthOrHeight: 1280,
-        useWebWorker: true
+        useWebWorker: true,
       });
-      return { uri: URL.createObjectURL(compressed), blob: compressed };
+      return { uri: URL.createObjectURL(compressed), blob: compressed, size: compressed.size };
     } else {
       const { Image } = await import("react-native-compressor" as any);
-      const compressedUri: string = await Image.compress(uri, { compressionMethod: "auto" });
-      return { uri: compressedUri };
+      const compressedUri: string = await Image.compress(uri, {
+        compressionMethod: "auto",
+        quality: percentage,
+      });
+      try {
+        const b = await fetch(compressedUri).then((r) => r.blob());
+        return { uri: compressedUri, size: b.size };
+      } catch {
+        return { uri: compressedUri };
+      }
     }
   }
 
   if (isVideo) {
     if (Platform.OS === "web") {
       const blob = await fetch(uri).then((r) => r.blob());
-      return { uri, blob };
+      const target = blob.size * (percentage / 100);
+      const compressed = await compressVideoWeb(blob, target);
+      return { uri: URL.createObjectURL(compressed), blob: compressed, size: compressed.size };
     }
 
     const { Video } = await import("react-native-compressor" as any);
     const compressedUri: string = await Video.compress(uri, {
-      compressionMethod: "auto"
+      compressionMethod: "auto",
+      quality: percentage,
     });
-    return { uri: compressedUri };
+    try {
+      const b = await fetch(compressedUri).then((r) => r.blob());
+      return { uri: compressedUri, size: b.size };
+    } catch {
+      return { uri: compressedUri };
+    }
   }
 
   return { uri };


### PR DESCRIPTION
## Summary
- add bucket constants to client
- compress video files on web and include compressed size
- provide helper to validate and upload assets from document picker

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `pnpm test` *(fails: packages field missing or empty)*

------
https://chatgpt.com/codex/tasks/task_b_684a68037020832b9c294db9097bc4a1