### PR TITLE
Switch DB layer to Sequelize

### DIFF
--- a/server/src/constants/index.ts
+++ b/server/src/constants/index.ts
@@ -19,6 +19,10 @@ export const CACHE_NAMESPACE_CONFIG = {
     namespace: "messages",
     ttl: 3600 * 24 * 2,
   },
+  Reactions: {
+    namespace: "reactions",
+    ttl: 1800,
+  },
   Sessions: {
     namespace: "session",
     ttl: 3600 * 24 * 30,

--- a/server/src/database/dbService.ts
+++ b/server/src/database/dbService.ts
@@ -1,0 +1,112 @@
+import { Model, ModelCtor, Op, Sequelize, Transaction } from "sequelize";
+import { getDBConnection } from "@connections/db";
+import { EQueryOperator } from "@/definitions/enums";
+
+type SimpleFilter = { column: string; operator: EQueryOperator; value: any };
+
+export default class DBService {
+  private sequelize: Sequelize;
+  constructor() {
+    this.sequelize = getDBConnection();
+  }
+
+  private buildWhere(filters: SimpleFilter[] = []) {
+    const where: any = {};
+    for (const { column, operator, value } of filters) {
+      switch (operator) {
+        case EQueryOperator.Eq:
+          where[column] = value;
+          break;
+        case EQueryOperator.Neq:
+          where[column] = { [Op.ne]: value };
+          break;
+        case EQueryOperator.Gt:
+          where[column] = { [Op.gt]: value };
+          break;
+        case EQueryOperator.Gte:
+          where[column] = { [Op.gte]: value };
+          break;
+        case EQueryOperator.Lt:
+          where[column] = { [Op.lt]: value };
+          break;
+        case EQueryOperator.Lte:
+          where[column] = { [Op.lte]: value };
+          break;
+        case EQueryOperator.Like:
+          where[column] = { [Op.like]: value };
+          break;
+        case EQueryOperator.ILike:
+          where[column] = { [Op.iLike]: value };
+          break;
+        case EQueryOperator.In:
+          where[column] = { [Op.in]: value as any[] };
+          break;
+        case EQueryOperator.Is:
+          where[column] = { [Op.is]: value };
+          break;
+        default:
+          where[column] = value;
+      }
+    }
+    return where;
+  }
+
+  async query<T extends Model>(model: ModelCtor<T>, {
+    query = [],
+    select,
+    modifyOptions,
+    count,
+  }: {
+    query?: SimpleFilter[];
+    select?: string;
+    modifyOptions?: (opts: any) => any;
+    count?: boolean;
+  }) {
+    let options: any = { where: this.buildWhere(query) };
+    if (select) options.attributes = select.split(",").map((s) => s.trim());
+    if (modifyOptions) options = modifyOptions(options) || options;
+
+    if (count) {
+      const res = await model.findAndCountAll(options);
+      return { data: res.rows as any, count: res.count, error: null };
+    }
+    const data = await model.findAll(options);
+    return { data: data as any, count: null, error: null };
+  }
+
+  async insert<T extends Model>(model: ModelCtor<T>, data: any) {
+    const res = await model.create(data as any);
+    return { data: [res.toJSON()] as any, error: null };
+  }
+
+  async updateById<T extends Model>(model: ModelCtor<T>, id: string, data: any) {
+    const [count, rows] = await model.update(data, {
+      where: { id },
+      returning: true,
+    });
+    return { data: rows[0] as any, error: null };
+  }
+
+  async deleteById<T extends Model>(model: ModelCtor<T>, id: string) {
+    const row = await model.findByPk(id);
+    if (!row) return { data: null, error: null };
+    await (row as any).destroy();
+    return { data: row.toJSON() as any, error: null };
+  }
+
+  async deleteByQuery<T extends Model>(model: ModelCtor<T>, filters: SimpleFilter[], single = false) {
+    const where = this.buildWhere(filters);
+    if (single) {
+      const row = await model.findOne({ where });
+      if (!row) return { data: null, error: null };
+      await (row as any).destroy();
+      return { data: row.toJSON() as any, error: null };
+    }
+    await model.destroy({ where });
+    return { data: null, error: null };
+  }
+
+  async transaction<T>(callback: (t: Transaction) => Promise<T>) {
+    return this.sequelize.transaction(callback);
+  }
+}

--- a/server/src/definitions/types/index.ts
+++ b/server/src/definitions/types/index.ts
@@ -63,6 +63,7 @@ export interface IBaseThread extends ITimeStamp {
   status: EAccessLevel;
   visibility: EAccessLevel;
   lockHistory: ILockHistory[];
+  parentId?: string | null;
   eventId: string;
   messages?: IMessage[];
 }

--- a/server/src/definitions/types/index.ts
+++ b/server/src/definitions/types/index.ts
@@ -48,6 +48,7 @@ export interface IMessage extends ITimeStamp {
   isEdited: boolean;
   threadId: string;
   user: IBaseUser;
+  reactions?: IReaction[];
 }
 
 // Thread Lock History
@@ -97,6 +98,7 @@ export interface IEvent extends ITimeStamp {
   capacity: number;
   tags: ITag[]; // Array of tag IDs
   media: IMedia[]; // Array of media IDs
+  reactions?: IReaction[];
 }
 
 // Tag Interface
@@ -142,6 +144,13 @@ export interface IMedia extends ITimeStamp {
 export interface IMediaEventJunction extends ITimeStamp {
   eventId: string;
   mediaId: string;
+}
+
+export interface IReaction extends ITimeStamp {
+  id: string;
+  contentId: string;
+  emoji: string;
+  userId: string;
 }
 
 export interface IPaginationParams {

--- a/server/src/features/Base.ts
+++ b/server/src/features/Base.ts
@@ -1,7 +1,8 @@
 import { EQueryOperator } from "@/definitions/enums";
 import { IPaginationParams } from "@/definitions/types";
-import SupabaseService, { SimpleFilter, SupabaseClient } from "@supabase";
-import { PostgrestError } from "@supabase/supabase-js";
+import SupabaseService from "@supabase"; // Deprecated for DB operations
+import DBService from "@/database/dbService";
+import { SimpleFilter } from "@supabase";
 import { omit } from "@utils";
 
 interface QuerySupabaseArgs<T> {
@@ -14,12 +15,15 @@ interface QuerySupabaseArgs<T> {
 export type BaseQueryArgs<T> = Omit<QuerySupabaseArgs<T>, "table">;
 
 class Base<T extends Record<string, any>> {
+  /** @deprecated Use _dbService for database operations */
   protected readonly _supabaseService: SupabaseService;
-  private readonly tableName: string;
+  protected readonly _dbService: DBService;
+  private readonly _model: any;
 
-  constructor(table: string) {
-    this.tableName = table;
+  constructor(model: any) {
+    this._model = model;
     this._supabaseService = new SupabaseService();
+    this._dbService = new DBService();
   }
 
   async getAll(
@@ -45,55 +49,52 @@ class Base<T extends Record<string, any>> {
 
     const from = (_pagination.page - 1) * _pagination.limit;
 
-    const { data, error, count } = await this._supabaseService.querySupabase<T>({
-      table: this.tableName,
-      modifyQuery: (qb: any) => {
-        if (_pagination?.sortOrder && _pagination?.sortBy) {
-          qb = qb.order(_pagination.sortBy, {
-            ascending: _pagination.sortOrder === "asc",
-          });
-        }
+    const filters = (args.query || []) as any[];
+    if (_pagination.next) {
+      filters.push({
+        column: _pagination.sortBy as any,
+        operator:
+          _pagination.sortOrder === "asc" ? EQueryOperator.Gt : EQueryOperator.Lt,
+        value: _pagination.next,
+      });
+    }
 
-        if (_pagination.startDate)
-          qb = qb.gte(_pagination.sortBy, _pagination.startDate);
-        if (_pagination.endDate)
-          qb = qb.lte(_pagination.sortBy, _pagination.endDate);
-
+    const { data, count } = await this._dbService.query<any>(this._model, {
+      query: filters,
+      select: args.select,
+      modifyOptions: (opts) => {
+        opts.order = [[_pagination.sortBy, _pagination.sortOrder.toUpperCase()]];
         if (_pagination.next) {
-          const params = [_pagination.sortBy, _pagination.next];
-          if (_pagination.sortOrder === "asc") {
-            qb = qb.gt(...params);
-          } else {
-            qb = qb.lt(...params);
-          }
-          qb = qb.limit(_pagination.limit + 1);
+          opts.limit = _pagination.limit + 1;
         } else {
-          qb = qb.range(from, from + _pagination.limit);
+          opts.offset = from;
+          opts.limit = _pagination.limit;
         }
-
-        if (args?.modifyQuery) qb = args.modifyQuery(qb);
-        return qb;
+        if (args.modifyQuery) opts = args.modifyQuery(opts) || opts;
+        return opts;
       },
-      ...args,
-      count: "exact",
+      count: true,
     });
 
-    if (error) throw new Error(error.message);
-
-    const paginationObj = {
+    let paginationObj: any = {
       limit: _pagination.limit,
       page: _pagination.page,
-      next:
-        data?.length > _pagination.limit
-          ? (data as T[])[_pagination.limit - 1]?.createdAt
-          : null,
-      hasNext: data?.length > _pagination.limit,
       total: count || 0,
+      hasNext: data?.length > _pagination.limit,
+      next: null as any,
     };
 
     if (_pagination.next) {
+      paginationObj.next =
+        data?.length > _pagination.limit
+          ? (data as T[])[_pagination.limit]?.createdAt
+          : null;
       delete paginationObj.page;
       delete paginationObj.hasNext;
+    } else {
+      paginationObj.next = paginationObj.hasNext
+        ? (data as T[])[_pagination.limit - 1]?.createdAt
+        : null;
     }
 
     return {
@@ -105,44 +106,24 @@ class Base<T extends Record<string, any>> {
     };
   }
 
-  getById(
-    id: string
-  ): Promise<{ data: T | null; error: PostgrestError | null }> {
-    return this._supabaseService.querySupabase<T>({
-      table: this.tableName,
-      query: [{ column: "id", operator: EQueryOperator.Eq, value: id }],
-      modifyQuery: (qb) => qb.maybeSingle(),
-    }) as Promise<{ data: T | null; error: PostgrestError | null }>;
+  getById(id: string): Promise<{ data: T | null; error: any }> {
+    return this._model
+      .findByPk(id)
+      .then((res: any) => ({ data: res, error: null }));
   }
 
-  async create(data: Partial<T>) {
+  async create(data: Partial<T>): Promise<{ data: T | null; error: any }> {
     const _data = omit(data, ["deletedAt", "updatedAt"]);
-    return this._supabaseService.insertIntoDB<Partial<T>>({
-      table: this.tableName,
-      data: _data,
-    }) as Promise<{
-      data: T[] | null;
-      error: PostgrestError | null;
-    }>;
+    return this._dbService.insert(this._model, _data);
   }
 
-  async update(id: string, data: Partial<T>) {
+  async update(id: string, data: Partial<T>): Promise<{ data: T | null; error: any }> {
     const _data = omit(data, ["id", "createdAt"]);
-    return this._supabaseService.updateById<T>({
-      table: this.tableName,
-      id,
-      data: _data,
-    });
+    return this._dbService.updateById(this._model, id, _data);
   }
 
-  delete(
-    id: string
-  ): Promise<{ data: T | null; error: PostgrestError | null }> {
-    return this._supabaseService.deleteById({
-      table: this.tableName,
-      id,
-      single: true,
-    });
+  delete(id: string): Promise<{ data: T | null; error: any }> {
+    return this._dbService.deleteById(this._model, id);
   }
 
   /**
@@ -168,8 +149,8 @@ class Base<T extends Record<string, any>> {
    *   return { user, profile };
    * });
    */
-  async withTransaction<T>(operation: (client: SupabaseClient) => Promise<T>) {
-    return this._supabaseService.transaction(operation);
+  async withTransaction<T>(operation: (tx: any) => Promise<T>) {
+    return this._dbService.transaction(operation);
   }
 }
 

--- a/server/src/features/Base.ts
+++ b/server/src/features/Base.ts
@@ -1,5 +1,6 @@
 import { EQueryOperator } from "@/definitions/enums";
 import { IPaginationParams } from "@/definitions/types";
+// Deprecated: Supabase service retained for backward compatibility
 import SupabaseService from "@supabase"; // Deprecated for DB operations
 import DBService from "@/database/dbService";
 import { SimpleFilter } from "@supabase";

--- a/server/src/features/events/constants.ts
+++ b/server/src/features/events/constants.ts
@@ -1,0 +1,1 @@
+export const EVENT_TABLE_NAME = "Events";

--- a/server/src/features/events/model.ts
+++ b/server/src/features/events/model.ts
@@ -56,6 +56,16 @@ Event.init(
       type: DataTypes.INTEGER,
       allowNull: false,
     },
+    tags: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+    },
+    media: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+    },
   },
   {
     modelName: "Event",

--- a/server/src/features/events/service.ts
+++ b/server/src/features/events/service.ts
@@ -11,6 +11,7 @@ import {
 import TagService from "../tags/service";
 import MediaService from "../media/service";
 import UserService from "../users/service";
+import ReactionService from "../reactions/service";
 import { validateEventCreate, validateEventUpdate } from "./validation";
 import { MethodCacheSync } from "@decorators";
 import {
@@ -32,6 +33,7 @@ class EventService extends Base<IEvent> {
   private readonly tagService: TagService;
   private readonly mediaService: MediaService;
   private readonly userService: UserService;
+  private readonly reactionService: ReactionService;
   private readonly getCache = getEventCache;
   private readonly setCache = setEventCache;
   private readonly deleteCache = deleteEventCache;
@@ -43,6 +45,7 @@ class EventService extends Base<IEvent> {
     this.tagService = new TagService();
     this.mediaService = new MediaService();
     this.userService = new UserService();
+    this.reactionService = new ReactionService();
   }
 
   @MethodCacheSync<IEvent>({})
@@ -108,6 +111,7 @@ class EventService extends Base<IEvent> {
       eventData.verifiers,
       "user"
     );
+    promises.reactions = this.reactionService.getReactions(`events/${id}`);
 
     // Wait for all promises to settle
     const settledResults = await Promise.allSettled(Object.values(promises));
@@ -127,6 +131,7 @@ class EventService extends Base<IEvent> {
     eventData.creator = resolvedData.creator?.data || null;
     eventData.participants = resolvedData.participants || [];
     eventData.verifiers = resolvedData.verifiers || [];
+    eventData.reactions = resolvedData.reactions?.data || [];
 
     // Construct the final response
     return {
@@ -198,27 +203,33 @@ class EventService extends Base<IEvent> {
       await Promise.all(
         data.items.map(async (event) => {
           const mediaPromise = this.mediaService.getEventMedia(event.id, 3);
-          const tagsPromise = this.tagService.getAllEventTags(event.id);
-          const participantsPromise =
-            this.userService.getAndPopulateUserProfiles(
-              event.participants,
-              "user"
-            );
-          const verifiersPromise = this.userService.getAndPopulateUserProfiles(
-            event.verifiers,
+        const tagsPromise = this.tagService.getAllEventTags(event.id);
+        const participantsPromise =
+          this.userService.getAndPopulateUserProfiles(
+            event.participants,
             "user"
           );
-          const [media, tags, participants, verifiers] = await Promise.all([
+        const verifiersPromise = this.userService.getAndPopulateUserProfiles(
+          event.verifiers,
+          "user"
+        );
+        const reactionsPromise = this.reactionService.getReactions(
+          `events/${event.id}`
+        );
+        const [media, tags, participants, verifiers, reactions] =
+          await Promise.all([
             mediaPromise,
             tagsPromise,
             participantsPromise,
             verifiersPromise,
+            reactionsPromise,
           ]);
-          event.media = media.data || [];
-          event.tags = tags.data || [];
-          event.participants = participants || [];
-          event.verifiers = verifiers || [];
-        })
+        event.media = media.data || [];
+        event.tags = tags.data || [];
+        event.participants = participants || [];
+        event.verifiers = verifiers || [];
+        event.reactions = reactions.data || [];
+      })
       );
 
       data.items = await this.userService.getAndPopulateUserProfiles(

--- a/server/src/features/index.ts
+++ b/server/src/features/index.ts
@@ -6,6 +6,7 @@ export { default as MessageService } from "./messages/service";
 export { default as ThreadService } from "./threads/service";
 export { default as MediaService } from "./media/service";
 export { default as AuthService } from "./auth/service";
+export { default as ReactionService } from "./reactions/service";
 export { RedisCache };
 
 export * from "./users/helpers";

--- a/server/src/features/index.ts
+++ b/server/src/features/index.ts
@@ -7,6 +7,7 @@ export { default as ThreadService } from "./threads/service";
 export { default as MediaService } from "./media/service";
 export { default as AuthService } from "./auth/service";
 export { default as ReactionService } from "./reactions/service";
+export * from "./reactions/helpers";
 export { RedisCache };
 
 export * from "./users/helpers";

--- a/server/src/features/media/model.ts
+++ b/server/src/features/media/model.ts
@@ -1,0 +1,40 @@
+import { getDBConnection } from "@connections/db";
+import { DataTypes, Model } from "sequelize";
+import { getUUIDv7 } from "@helpers";
+import { MEDIA_TABLE_NAME } from "./constants";
+import { EMediaType, EAccessLevel } from "@definitions/enums";
+
+export class Media extends Model {}
+
+Media.init(
+  {
+    id: { type: DataTypes.UUID, primaryKey: true, defaultValue: () => getUUIDv7() },
+    type: { type: DataTypes.ENUM(...Object.values(EMediaType)), allowNull: false },
+    url: { type: DataTypes.TEXT, allowNull: false },
+    name: { type: DataTypes.TEXT, allowNull: false },
+    caption: { type: DataTypes.TEXT },
+    thumbnail: { type: DataTypes.TEXT },
+    size: { type: DataTypes.INTEGER },
+    mimeType: { type: DataTypes.TEXT },
+    duration: { type: DataTypes.INTEGER },
+    uploader: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: { model: "Users", key: "id" },
+    },
+    storage: { type: DataTypes.JSONB, allowNull: false },
+    access: { type: DataTypes.ENUM(...Object.values(EAccessLevel)), allowNull: false },
+    metadata: { type: DataTypes.JSONB, allowNull: false, defaultValue: {} },
+  },
+  {
+    modelName: "Media",
+    tableName: MEDIA_TABLE_NAME,
+    sequelize: getDBConnection(),
+    timestamps: true,
+    paranoid: true,
+  }
+);
+
+(async () => {
+  await Media.sync({ alter: true });
+})();

--- a/server/src/features/messages/model.ts
+++ b/server/src/features/messages/model.ts
@@ -1,0 +1,39 @@
+import { getDBConnection } from "@connections/db";
+import { DataTypes, Model } from "sequelize";
+import { getUUIDv7 } from "@helpers";
+import { MESSAGE_TABLE_NAME } from "./constants";
+
+export class Message extends Model {}
+
+Message.init(
+  {
+    id: { type: DataTypes.UUID, primaryKey: true, defaultValue: () => getUUIDv7() },
+    userId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: { model: "Users", key: "id" },
+    },
+    parentId: {
+      type: DataTypes.UUID,
+      references: { model: "Messages", key: "id" },
+    },
+    content: { type: DataTypes.JSONB, allowNull: false },
+    isEdited: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    threadId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: { model: "Threads", key: "id" },
+    },
+  },
+  {
+    modelName: "Message",
+    tableName: MESSAGE_TABLE_NAME,
+    sequelize: getDBConnection(),
+    timestamps: true,
+    paranoid: true,
+  }
+);
+
+(async () => {
+  await Message.sync({ alter: true });
+})();

--- a/server/src/features/messages/service.ts
+++ b/server/src/features/messages/service.ts
@@ -136,12 +136,13 @@ class MessageService extends Base<IMessage> {
           "user"
         );
 
-      for (const msg of userPopulatedMessages) {
-        const { data: reactions } = await this.reactionService.getReactions(
-          `messages/${msg.id}`
-        );
-        msg.reactions = reactions;
-      }
+      const reactionPromises = userPopulatedMessages.map((msg) =>
+        this.reactionService.getReactions(`messages/${msg.id}`)
+      );
+      const reactionResults = await Promise.all(reactionPromises);
+      userPopulatedMessages.forEach((msg, idx) => {
+        msg.reactions = reactionResults[idx].data;
+      });
 
       return {
         data: { items: userPopulatedMessages, pagination: data.pagination },

--- a/server/src/features/reactions/constants.ts
+++ b/server/src/features/reactions/constants.ts
@@ -1,2 +1,3 @@
 export const REACTION_TABLE_NAME = "Reactions";
 export const COMMON_EMOJIS = ["👍", "❤️", "😂", "🎉", "😮", "😢"];
+export const ALLOWED_REACTION_TABLES = ["events", "messages", "threads"];

--- a/server/src/features/reactions/constants.ts
+++ b/server/src/features/reactions/constants.ts
@@ -1,0 +1,2 @@
+export const REACTION_TABLE_NAME = "Reactions";
+export const COMMON_EMOJIS = ["👍", "❤️", "😂", "🎉", "😮", "😢"];

--- a/server/src/features/reactions/helpers.ts
+++ b/server/src/features/reactions/helpers.ts
@@ -1,0 +1,12 @@
+import { RedisCache } from "@features/cache";
+import { CACHE_NAMESPACE_CONFIG } from "@constants";
+import { IReaction } from "@definitions/types";
+
+const reactionCache = new RedisCache({
+  namespace: CACHE_NAMESPACE_CONFIG.Reactions.namespace,
+  defaultTTLSeconds: CACHE_NAMESPACE_CONFIG.Reactions.ttl,
+});
+
+export const getReactionCache = (key: string) => reactionCache.getItem<IReaction[]>(key);
+export const setReactionCache = (key: string, value: IReaction[]) => reactionCache.setItem(key, value);
+export const deleteReactionCache = (key: string) => reactionCache.deleteItem(key);

--- a/server/src/features/reactions/model.ts
+++ b/server/src/features/reactions/model.ts
@@ -1,7 +1,7 @@
 import { getDBConnection } from "@connections/db";
 import { DataTypes, Model } from "sequelize";
 import { getUUIDv7 } from "@helpers";
-import { REACTION_TABLE_NAME, ALLOWED_REACTION_TABLES } from "./constants";
+import { REACTION_TABLE_NAME } from "./constants";
 
 export class Reaction extends Model {}
 
@@ -12,18 +12,7 @@ Reaction.init(
       primaryKey: true,
       defaultValue: () => getUUIDv7(),
     },
-    contentId: {
-      type: DataTypes.TEXT,
-      allowNull: false,
-      validate: {
-        isValidContentId(value: string) {
-          const [table] = value.split("/");
-          if (!ALLOWED_REACTION_TABLES.includes(table)) {
-            throw new Error(`Invalid reaction table: ${table}`);
-          }
-        },
-      },
-    },
+    contentId: { type: DataTypes.TEXT, allowNull: false },
     emoji: { type: DataTypes.TEXT, allowNull: false },
     userId: {
       type: DataTypes.UUID,

--- a/server/src/features/reactions/model.ts
+++ b/server/src/features/reactions/model.ts
@@ -1,0 +1,34 @@
+import { getDBConnection } from "@connections/db";
+import { DataTypes, Model } from "sequelize";
+import { getUUIDv7 } from "@helpers";
+import { REACTION_TABLE_NAME } from "./constants";
+
+export class Reaction extends Model {}
+
+Reaction.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      defaultValue: () => getUUIDv7(),
+    },
+    contentId: { type: DataTypes.TEXT, allowNull: false },
+    emoji: { type: DataTypes.TEXT, allowNull: false },
+    userId: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: { model: "Users", key: "id" },
+    },
+  },
+  {
+    modelName: "Reaction",
+    tableName: REACTION_TABLE_NAME,
+    sequelize: getDBConnection(),
+    timestamps: true,
+    paranoid: true,
+  }
+);
+
+(async () => {
+  await Reaction.sync({ alter: true });
+})();

--- a/server/src/features/reactions/model.ts
+++ b/server/src/features/reactions/model.ts
@@ -1,7 +1,7 @@
 import { getDBConnection } from "@connections/db";
 import { DataTypes, Model } from "sequelize";
 import { getUUIDv7 } from "@helpers";
-import { REACTION_TABLE_NAME } from "./constants";
+import { REACTION_TABLE_NAME, ALLOWED_REACTION_TABLES } from "./constants";
 
 export class Reaction extends Model {}
 
@@ -12,7 +12,18 @@ Reaction.init(
       primaryKey: true,
       defaultValue: () => getUUIDv7(),
     },
-    contentId: { type: DataTypes.TEXT, allowNull: false },
+    contentId: {
+      type: DataTypes.TEXT,
+      allowNull: false,
+      validate: {
+        isValidContentId(value: string) {
+          const [table] = value.split("/");
+          if (!ALLOWED_REACTION_TABLES.includes(table)) {
+            throw new Error(`Invalid reaction table: ${table}`);
+          }
+        },
+      },
+    },
     emoji: { type: DataTypes.TEXT, allowNull: false },
     userId: {
       type: DataTypes.UUID,
@@ -26,6 +37,7 @@ Reaction.init(
     sequelize: getDBConnection(),
     timestamps: true,
     paranoid: true,
+    indexes: [{ fields: ["contentId"] }],
   }
 );
 

--- a/server/src/features/reactions/service.ts
+++ b/server/src/features/reactions/service.ts
@@ -1,0 +1,27 @@
+import { IReaction, IPaginationParams } from "@/definitions/types";
+import Base, { BaseQueryArgs } from "../Base";
+import { Reaction } from "./model";
+import { EQueryOperator } from "@/definitions/enums";
+
+class ReactionService extends Base<IReaction> {
+  constructor() {
+    super(Reaction);
+  }
+
+  async getAll(
+    args?: BaseQueryArgs<IReaction>,
+    pagination?: Partial<IPaginationParams>
+  ) {
+    return super.getAll(args, pagination);
+  }
+
+  async getReactions(contentId: string) {
+    const { data } = await super.getAll(
+      { query: [{ column: "contentId", operator: EQueryOperator.Eq, value: contentId }] },
+      { limit: 1000 }
+    );
+    return { data: data.items || [], error: null };
+  }
+}
+
+export default ReactionService;

--- a/server/src/features/reactions/service.ts
+++ b/server/src/features/reactions/service.ts
@@ -1,6 +1,10 @@
 import { IReaction, IPaginationParams } from "@/definitions/types";
 import Base, { BaseQueryArgs } from "../Base";
 import { Reaction } from "./model";
+import {
+  validateReactionCreate,
+  validateReactionUpdate,
+} from "./validation";
 import { EQueryOperator } from "@/definitions/enums";
 import { MethodCacheSync } from "@decorators";
 import {
@@ -23,6 +27,23 @@ class ReactionService extends Base<IReaction> {
     pagination?: Partial<IPaginationParams>
   ) {
     return super.getAll(args, pagination);
+  }
+
+  @MethodCacheSync<IReaction>()
+  async create<U extends Partial<Omit<IReaction, "id" | "updatedAt">>>(data: U) {
+    return validateReactionCreate(data, (validData) => super.create(validData));
+  }
+
+  @MethodCacheSync<IReaction>()
+  async update<U extends Partial<IReaction>>(id: string, data: U) {
+    return validateReactionUpdate(data, (validData) =>
+      super.update(id, validData)
+    );
+  }
+
+  @MethodCacheSync<IReaction>()
+  delete(id: string) {
+    return super.delete(id);
   }
 
   @MethodCacheSync<IReaction[]>({

--- a/server/src/features/reactions/service.ts
+++ b/server/src/features/reactions/service.ts
@@ -2,8 +2,18 @@ import { IReaction, IPaginationParams } from "@/definitions/types";
 import Base, { BaseQueryArgs } from "../Base";
 import { Reaction } from "./model";
 import { EQueryOperator } from "@/definitions/enums";
+import { MethodCacheSync } from "@decorators";
+import {
+  deleteReactionCache,
+  getReactionCache,
+  setReactionCache,
+} from "./helpers";
 
 class ReactionService extends Base<IReaction> {
+  private readonly getCache = getReactionCache;
+  private readonly setCache = setReactionCache;
+  private readonly deleteCache = deleteReactionCache;
+
   constructor() {
     super(Reaction);
   }
@@ -15,9 +25,18 @@ class ReactionService extends Base<IReaction> {
     return super.getAll(args, pagination);
   }
 
+  @MethodCacheSync<IReaction[]>({
+    cacheGetter: getReactionCache,
+    cacheSetter: setReactionCache,
+    cacheDeleter: deleteReactionCache,
+  })
   async getReactions(contentId: string) {
     const { data } = await super.getAll(
-      { query: [{ column: "contentId", operator: EQueryOperator.Eq, value: contentId }] },
+      {
+        query: [
+          { column: "contentId", operator: EQueryOperator.Eq, value: contentId },
+        ],
+      },
       { limit: 1000 }
     );
     return { data: data.items || [], error: null };

--- a/server/src/features/reactions/validation.ts
+++ b/server/src/features/reactions/validation.ts
@@ -1,0 +1,71 @@
+import { validateSchema } from "@/helpers";
+import { REACTION_TABLE_NAME, COMMON_EMOJIS, ALLOWED_REACTION_TABLES } from "./constants";
+
+const basePattern = `^(${ALLOWED_REACTION_TABLES.join("|")})\\/[0-9a-fA-F-]{36}$`;
+
+const reactionSchema = {
+  type: "object",
+  properties: {
+    contentId: {
+      type: "string",
+      pattern: basePattern,
+      errorMessage: `contentId must be of the form '<table>/<uuid>' where table is one of ${ALLOWED_REACTION_TABLES.join(", ")}`,
+    },
+    emoji: {
+      type: "string",
+      enum: COMMON_EMOJIS,
+      errorMessage: "emoji must be one of the supported emojis",
+    },
+    userId: {
+      type: "string",
+      format: "uuid",
+      errorMessage: "userId must be a valid UUID",
+    },
+  },
+  required: ["contentId", "emoji", "userId"],
+  additionalProperties: false,
+  errorMessage: {
+    type: "Reaction data must be an object",
+    required: {
+      contentId: "contentId is required",
+      emoji: "emoji is required",
+      userId: "userId is required",
+    },
+  },
+};
+
+const updateSchema = {
+  type: "object",
+  properties: {
+    contentId: {
+      type: "string",
+      pattern: basePattern,
+      errorMessage: `contentId must be of the form '<table>/<uuid>' where table is one of ${ALLOWED_REACTION_TABLES.join(", ")}`,
+    },
+    emoji: {
+      type: "string",
+      enum: COMMON_EMOJIS,
+      errorMessage: "emoji must be one of the supported emojis",
+    },
+    userId: {
+      type: "string",
+      format: "uuid",
+      errorMessage: "userId must be a valid UUID",
+    },
+  },
+  additionalProperties: false,
+  errorMessage: {
+    type: "Reaction data must be an object",
+  },
+};
+
+export const validateReactionCreate = validateSchema(
+  `${REACTION_TABLE_NAME}_CREATE`,
+  reactionSchema
+);
+
+export const validateReactionUpdate = validateSchema(
+  `${REACTION_TABLE_NAME}_UPDATE`,
+  updateSchema
+);
+

--- a/server/src/features/tags/model.ts
+++ b/server/src/features/tags/model.ts
@@ -1,0 +1,30 @@
+import { getDBConnection } from "@connections/db";
+import { DataTypes, Model } from "sequelize";
+import { getUUIDv7 } from "@helpers";
+import { TAG_TABLE_NAME } from "./constants";
+
+export class Tag extends Model {}
+
+Tag.init(
+  {
+    id: { type: DataTypes.UUID, primaryKey: true, defaultValue: () => getUUIDv7() },
+    name: { type: DataTypes.TEXT, allowNull: false },
+    value: { type: DataTypes.TEXT, allowNull: false, unique: true },
+    description: { type: DataTypes.TEXT },
+    icon: { type: DataTypes.TEXT },
+    color: { type: DataTypes.TEXT },
+    parentId: { type: DataTypes.UUID, references: { model: "Tags", key: "id" } },
+    createdBy: { type: DataTypes.UUID, references: { model: "Users", key: "id" } },
+  },
+  {
+    modelName: "Tag",
+    tableName: TAG_TABLE_NAME,
+    sequelize: getDBConnection(),
+    timestamps: true,
+    paranoid: true,
+  }
+);
+
+(async () => {
+  await Tag.sync({ alter: true });
+})();

--- a/server/src/features/threads/model.ts
+++ b/server/src/features/threads/model.ts
@@ -1,0 +1,33 @@
+import { getDBConnection } from "@connections/db";
+import { DataTypes, Model } from "sequelize";
+import { getUUIDv7 } from "@helpers";
+import { THREAD_TABLE_NAME } from "./constants";
+import { EThreadType, EAccessLevel } from "@definitions/enums";
+
+export class Thread extends Model {}
+
+Thread.init(
+  {
+    id: { type: DataTypes.UUID, primaryKey: true, defaultValue: () => getUUIDv7() },
+    type: { type: DataTypes.ENUM(...Object.values(EThreadType)), allowNull: false },
+    status: { type: DataTypes.ENUM(...Object.values(EAccessLevel)), allowNull: false },
+    visibility: { type: DataTypes.ENUM(...Object.values(EAccessLevel)), allowNull: false },
+    parentId: { type: DataTypes.UUID, references: { model: "Threads", key: "id" } },
+    eventId: {
+      type: DataTypes.UUID,
+      references: { model: "Events", key: "id" },
+    },
+    lockHistory: { type: DataTypes.JSONB, defaultValue: {} },
+  },
+  {
+    modelName: "Thread",
+    tableName: THREAD_TABLE_NAME,
+    sequelize: getDBConnection(),
+    timestamps: true,
+    paranoid: true,
+  }
+);
+
+(async () => {
+  await Thread.sync({ alter: true });
+})();

--- a/server/src/features/threads/service.ts
+++ b/server/src/features/threads/service.ts
@@ -2,12 +2,13 @@ import Base from "../Base";
 import MessageService from "../messages/service";
 import { validateThreadCreate, validateThreadUpdate } from "./validation";
 import { THREAD_TABLE_NAME } from "./constants";
+import { Thread } from "./model";
 import MediaService from "@features/media/service";
-import { PostgrestError } from "@supabase/postgrest-js";
 import { EQueryOperator, EThreadType } from "@definitions/enums";
 import { MethodCacheSync } from "@decorators";
 import { getThreadCache, setThreadCache, deleteThreadCache } from "./helpers";
 import { IBaseThread } from "@definitions/types";
+import { BadRequestError } from "@exceptions";
 
 class ThreadsService extends Base<IBaseThread> {
   private readonly getCache = getThreadCache;
@@ -15,7 +16,7 @@ class ThreadsService extends Base<IBaseThread> {
   private readonly deleteCache = deleteThreadCache;
 
   constructor() {
-    super(THREAD_TABLE_NAME);
+    super(Thread);
   }
 
   async _getByIdNoCache(id: string) {
@@ -26,20 +27,36 @@ class ThreadsService extends Base<IBaseThread> {
   async create<U extends Partial<Omit<IBaseThread, "id" | "updatedAt">>>(
     data: U
   ) {
-    return validateThreadCreate(data, (data) => super.create(data));
+    return validateThreadCreate(data, async (validData) => {
+      if (validData.parentId) {
+        const parent = await this.getById(validData.parentId);
+        if (!parent.data) throw new BadRequestError("Parent thread not found");
+        if (parent.data.parentId)
+          throw new BadRequestError("Nested threads beyond one level are not allowed");
+      }
+      return super.create(validData);
+    });
   }
 
   @MethodCacheSync<IBaseThread>({})
   async getById(id: string): Promise<{
     data: IBaseThread;
-    error: PostgrestError | null;
+    error: any;
   }> {
     return super.getById(id);
   }
 
   @MethodCacheSync<IBaseThread>({})
   async update<U extends Partial<IBaseThread>>(id: string, data: U) {
-    return validateThreadUpdate(data, (data) => super.update(id, data));
+    return validateThreadUpdate(data, async (validData) => {
+      if (validData.parentId) {
+        const parent = await this.getById(validData.parentId);
+        if (!parent.data) throw new BadRequestError("Parent thread not found");
+        if (parent.data.parentId)
+          throw new BadRequestError("Nested threads beyond one level are not allowed");
+      }
+      return super.update(id, validData);
+    });
   }
 }
 

--- a/server/src/features/users/helpers.ts
+++ b/server/src/features/users/helpers.ts
@@ -176,6 +176,12 @@ export const getSafeUser = (user: IBaseUser) => {
   return _user;
 };
 
+export const getLeanUser = (user: IBaseUser) => {
+  const safe = getSafeUser(user);
+  const { id, name, createdAt, deletedAt, username, email } = safe;
+  return { id, name, createdAt, deletedAt, username, email } as IBaseUser;
+};
+
 export const getUserInterestsCache = (userId: string) => {
   return userCache.getItem<ITag[]>(`${userId}:interests`);
 };

--- a/server/src/features/users/model.ts
+++ b/server/src/features/users/model.ts
@@ -1,0 +1,40 @@
+import { getDBConnection } from "@connections/db";
+import { DataTypes, Model } from "sequelize";
+import { getUUIDv7 } from "@helpers";
+import { USER_TABLE_NAME } from "./constants";
+
+export class User extends Model {}
+
+User.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      defaultValue: () => getUUIDv7(),
+    },
+    name: { type: DataTypes.TEXT, allowNull: false },
+    email: { type: DataTypes.TEXT, allowNull: false, unique: true },
+    gender: { type: DataTypes.TEXT, allowNull: false },
+    address: { type: DataTypes.JSONB },
+    isVerified: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
+    profilePic: { type: DataTypes.JSONB },
+    mediaId: {
+      type: DataTypes.UUID,
+      references: { model: "Media", key: "id" },
+    },
+    username: { type: DataTypes.TEXT },
+    password: { type: DataTypes.TEXT },
+    meta: { type: DataTypes.JSONB, defaultValue: {} },
+  },
+  {
+    modelName: "User",
+    tableName: USER_TABLE_NAME,
+    sequelize: getDBConnection(),
+    timestamps: true,
+    paranoid: true,
+  }
+);
+
+(async () => {
+  await User.sync({ alter: true });
+})();

--- a/server/src/features/users/service.ts
+++ b/server/src/features/users/service.ts
@@ -11,6 +11,7 @@ import {
   deleteUserCache,
   deleteUserInterestsCache,
   getSafeUser,
+  getLeanUser,
   getUserCache,
   getUserCacheByEmail,
   getUserCacheByUsername,
@@ -247,11 +248,11 @@ class UserService extends Base<IBaseUser> {
     const { data: mediaData } = await this.mediaService.getMediaByIds(mediaIds);
 
     const safeUsers = fetchedUsers.reduce((acc, user) => {
-      acc[user.id] = getSafeUser({
+      acc[user.id] = getLeanUser({
         ...user,
         mediaId: mediaData[user.mediaId as string],
       });
-
+      
       return acc;
     }, {} as Record<string, IBaseUser>);
 

--- a/server/src/features/users/service.ts
+++ b/server/src/features/users/service.ts
@@ -3,7 +3,7 @@ import Base from "../Base";
 import { validateUserCreate, validateUserUpdate } from "./validation";
 import { EQueryOperator } from "@/definitions/enums";
 import { USER_TABLE_NAME } from "./constants";
-import { PostgrestError } from "@supabase/supabase-js";
+import { User } from "./model";
 import {
   bulkGetUserCache,
   bulkSetUserCache,
@@ -35,7 +35,7 @@ class UserService extends Base<IBaseUser> {
   private readonly mediaService: MediaService;
 
   constructor() {
-    super(USER_TABLE_NAME);
+    super(User);
     this.tagService = new TagService();
     this.mediaService = new MediaService();
   }
@@ -47,7 +47,7 @@ class UserService extends Base<IBaseUser> {
   @MethodCacheSync<IBaseUser>()
   async create(
     data: Partial<IBaseUser>
-  ): Promise<{ data: IBaseUser[] | null; error: PostgrestError | null }> {
+  ): Promise<{ data: IBaseUser[] | null; error: any }> {
     return validateUserCreate(data, (data) => super.create(data));
   }
 
@@ -136,7 +136,7 @@ class UserService extends Base<IBaseUser> {
   @MethodCacheSync<IBaseUser>({})
   async getById(
     id: string
-  ): Promise<{ data: IBaseUser; error: PostgrestError | null }> {
+  ): Promise<{ data: IBaseUser; error: any }> {
     const { data, error } = await super.getById(id);
     if (error) throw error;
     if (data.mediaId) {
@@ -154,17 +154,11 @@ class UserService extends Base<IBaseUser> {
     cacheSetter: setUserCacheByEmail,
   })
   getUserByEmail(email: string) {
-    return this._supabaseService.querySupabase({
-      table: USER_TABLE_NAME,
+    return this._dbService.query(User, {
       query: [
-        {
-          column: "email",
-          operator: EQueryOperator.Eq,
-          value: email,
-        },
+        { column: "email", operator: EQueryOperator.Eq, value: email },
       ],
-      modifyQuery: (qb) => qb.maybeSingle(),
-    }) as Promise<{ data: IBaseUser | null; error: PostgrestError | null }>;
+    }) as any;
   }
 
   @MethodCacheSync<IBaseUser>({
@@ -172,17 +166,11 @@ class UserService extends Base<IBaseUser> {
     cacheSetter: setUserCacheByUsername,
   })
   getUserByUsername(username: string) {
-    return this._supabaseService.querySupabase({
-      table: USER_TABLE_NAME,
+    return this._dbService.query(User, {
       query: [
-        {
-          column: "username",
-          operator: EQueryOperator.Eq,
-          value: username,
-        },
+        { column: "username", operator: EQueryOperator.Eq, value: username },
       ],
-      modifyQuery: (qb) => qb.maybeSingle(),
-    }) as Promise<{ data: IBaseUser | null; error: PostgrestError | null }>;
+    }) as any;
   }
 
   @MethodCacheSync<IBaseUser>({
@@ -220,7 +208,7 @@ class UserService extends Base<IBaseUser> {
 
   async getUserProfiles(ids: string[]): Promise<{
     data: Record<string, IBaseUser>;
-    error: PostgrestError | null;
+    error: any;
   }> {
     let fetchedUsers = await bulkGetUserCache(ids);
 

--- a/server/src/helpers/validation.ts
+++ b/server/src/helpers/validation.ts
@@ -1,7 +1,6 @@
 import Ajv, { ValidateFunction } from "ajv";
 import addFormats from "ajv-formats";
 import addErrors from "ajv-errors";
-import { PostgrestError } from "@supabase/supabase-js";
 import { BadRequestError } from "@exceptions";
 
 // Initialize AJV with options
@@ -48,7 +47,7 @@ export const validateSchema = (schemaName: string, schema: object) => {
   return <T, R>(
     data: T,
     callback: (validData: T) => R
-  ): R | { data: null; error: PostgrestError } => {
+  ): R | { data: null; error: any } => {
     const isValid = validate(data);
     if (!isValid) {
       const errors = validate.errors

--- a/server/src/helpers/validation.ts
+++ b/server/src/helpers/validation.ts
@@ -50,12 +50,7 @@ export const validateSchema = (schemaName: string, schema: object) => {
   ): R | { data: null; error: any } => {
     const isValid = validate(data);
     if (!isValid) {
-      const errors = validate.errors
-        ?.map(
-          (error) =>
-            error.message + " " + Object.values(error.params).join(", ")
-        )
-        .join(", ");
+      const errors = ajv.errorsText(validate.errors, { separator: ", " });
       throw new BadRequestError(errors);
     }
     return callback(data);

--- a/server/src/supabase/index.ts
+++ b/server/src/supabase/index.ts
@@ -1,3 +1,4 @@
+// Deprecated: Supabase service retained for legacy support
 import { PostgrestError } from "@supabase/supabase-js";
 import {
   PostgrestBuilder,

--- a/server/src/supabase/index.ts
+++ b/server/src/supabase/index.ts
@@ -1,4 +1,5 @@
 // Deprecated: Supabase service retained for legacy support
+// Postgrest types kept for backwards compatibility with old DB service
 import { PostgrestError } from "@supabase/supabase-js";
 import {
   PostgrestBuilder,


### PR DESCRIPTION
## Summary
- replace EventMedia and EventTag tables with JSON fields on `Event`
- remove PostgrestError usage from Base and services
- implement cursor based pagination in Base
- ensure only single‑level nesting for threads and messages
- update services to manage tags and media arrays on events

## Testing
- `npm run build` *(fails: Cannot find module 'cors' or type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_684b1b537da8832b907c5dff25f75cfc