### PR TITLE
Refactor models and TagService

### DIFF
--- a/server/src/features/media/model.ts
+++ b/server/src/features/media/model.ts
@@ -3,8 +3,10 @@ import { DataTypes, Model } from "sequelize";
 import { getUUIDv7 } from "@helpers";
 import { MEDIA_TABLE_NAME } from "./constants";
 import { EMediaType, EAccessLevel } from "@definitions/enums";
+import { IMedia } from "@/definitions/types";
+type MediaAttributes = Omit<IMedia, "createdAt" | "updatedAt" | "deletedAt" | "path" | "publicUrl" | "publicUrlExpiresAt">;
 
-export class Media extends Model {}
+export class Media extends Model<MediaAttributes, MediaAttributes> {}
 
 Media.init(
   {

--- a/server/src/features/messages/model.ts
+++ b/server/src/features/messages/model.ts
@@ -2,8 +2,10 @@ import { getDBConnection } from "@connections/db";
 import { DataTypes, Model } from "sequelize";
 import { getUUIDv7 } from "@helpers";
 import { MESSAGE_TABLE_NAME } from "./constants";
+import { IMessage } from "@/definitions/types";
+type MessageAttributes = Omit<IMessage, "createdAt" | "updatedAt" | "deletedAt" | "user" | "reactions">;
 
-export class Message extends Model {}
+export class Message extends Model<MessageAttributes, MessageAttributes> {}
 
 Message.init(
   {

--- a/server/src/features/reactions/model.ts
+++ b/server/src/features/reactions/model.ts
@@ -2,8 +2,10 @@ import { getDBConnection } from "@connections/db";
 import { DataTypes, Model } from "sequelize";
 import { getUUIDv7 } from "@helpers";
 import { REACTION_TABLE_NAME } from "./constants";
+import { IReaction } from "@/definitions/types";
+type ReactionAttributes = Omit<IReaction, "createdAt" | "updatedAt" | "deletedAt">;
 
-export class Reaction extends Model {}
+export class Reaction extends Model<ReactionAttributes, ReactionAttributes> {}
 
 Reaction.init(
   {

--- a/server/src/features/tags/model.ts
+++ b/server/src/features/tags/model.ts
@@ -2,8 +2,10 @@ import { getDBConnection } from "@connections/db";
 import { DataTypes, Model } from "sequelize";
 import { getUUIDv7 } from "@helpers";
 import { TAG_TABLE_NAME } from "./constants";
+import { ITag } from "@/definitions/types";
+type TagAttributes = Omit<ITag, "createdAt" | "updatedAt" | "deletedAt">;
 
-export class Tag extends Model {}
+export class Tag extends Model<TagAttributes, TagAttributes> {}
 
 Tag.init(
   {

--- a/server/src/features/threads/model.ts
+++ b/server/src/features/threads/model.ts
@@ -3,8 +3,10 @@ import { DataTypes, Model } from "sequelize";
 import { getUUIDv7 } from "@helpers";
 import { THREAD_TABLE_NAME } from "./constants";
 import { EThreadType, EAccessLevel } from "@definitions/enums";
+import { IBaseThread } from "@/definitions/types";
+type ThreadAttributes = Omit<IBaseThread, "createdAt" | "updatedAt" | "deletedAt" | "messages">;
 
-export class Thread extends Model {}
+export class Thread extends Model<ThreadAttributes, ThreadAttributes> {}
 
 Thread.init(
   {

--- a/server/src/features/users/model.ts
+++ b/server/src/features/users/model.ts
@@ -2,8 +2,13 @@ import { getDBConnection } from "@connections/db";
 import { DataTypes, Model } from "sequelize";
 import { getUUIDv7 } from "@helpers";
 import { USER_TABLE_NAME } from "./constants";
+import { IBaseUser } from "@/definitions/types";
+type UserAttributes = Omit<IBaseUser, "createdAt" | "updatedAt" | "deletedAt" | "media" | "profilePic"> & {
+  profilePic: Record<string, any> | null;
+  media?: any;
+};
 
-export class User extends Model {}
+export class User extends Model<UserAttributes, UserAttributes> {}
 
 User.init(
   {

--- a/server/src/utils/dbUtils.ts
+++ b/server/src/utils/dbUtils.ts
@@ -1,0 +1,111 @@
+import { FindOptions, Model, ModelCtor, Op, Transaction } from "sequelize";
+import { IPaginationParams } from "@/definitions/types";
+
+export interface PaginatedResult<T> {
+  items: T[];
+  pagination: IPaginationParams;
+}
+
+export async function findAllWithPagination<T extends Model>(
+  model: ModelCtor<T>,
+  where: Record<string, any> = {},
+  pagination: Partial<IPaginationParams> = {},
+  select?: string,
+  modifyOptions?: (opts: FindOptions) => FindOptions
+): Promise<{ data: PaginatedResult<T>; error: any }> {
+  const {
+    limit = 10,
+    page = 1,
+    next = null,
+    sortBy = "createdAt",
+    sortOrder = "desc",
+  } = pagination;
+
+  const options: FindOptions = {
+    where: { ...where },
+    order: [[sortBy, sortOrder.toUpperCase() as any]],
+  };
+
+  if (select) options.attributes = select.split(",").map((s) => s.trim());
+
+  if (next) {
+    (options.where as any)[sortBy] = {
+      [sortOrder === "asc" ? Op.gt : Op.lt]: next,
+    };
+    options.limit = limit + 1;
+  } else {
+    options.limit = limit;
+    options.offset = (page - 1) * limit;
+  }
+
+  if (modifyOptions) modifyOptions(options);
+
+  const { rows, count } = await model.findAndCountAll(options);
+  const resultItems = rows.slice(0, limit) as T[];
+  const paginationObj: IPaginationParams = {
+    limit,
+    page,
+    next: null,
+    total: count,
+    sortBy,
+    sortOrder,
+  } as IPaginationParams;
+
+  paginationObj.hasNext = rows.length > limit;
+
+  if (next) {
+    paginationObj.next =
+      rows.length > limit ? (rows as any)[limit][sortBy] : null;
+    delete paginationObj.page;
+    delete paginationObj.hasNext;
+  } else {
+    paginationObj.next = paginationObj.hasNext
+      ? (rows as any)[limit - 1][sortBy]
+      : null;
+  }
+
+  return { data: { items: resultItems, pagination: paginationObj }, error: null };
+}
+
+export async function findById<T extends Model>(
+  model: ModelCtor<T>,
+  id: string
+): Promise<{ data: T | null; error: any }> {
+  const res = await model.findByPk(id, { raw: true });
+  return { data: res as any, error: null };
+}
+
+export async function createRecord<T extends Model>(
+  model: ModelCtor<T>,
+  data: Partial<T>
+): Promise<{ data: T | null; error: any }> {
+  const row = await model.create(data as any);
+  return { data: row.toJSON() as any, error: null };
+}
+
+export async function updateRecord<T extends Model>(
+  model: ModelCtor<T>,
+  id: string,
+  data: Partial<T>
+): Promise<{ data: T | null; error: any }> {
+  await model.update(data as any, { where: { id } });
+  const updated = await model.findByPk(id, { raw: true });
+  return { data: updated as any, error: null };
+}
+
+export async function deleteRecord<T extends Model>(
+  model: ModelCtor<T>,
+  id: string
+): Promise<{ data: T | null; error: any }> {
+  const row = await model.findByPk(id);
+  if (!row) return { data: null, error: null };
+  await (row as any).destroy();
+  return { data: row.toJSON() as any, error: null };
+}
+
+export async function runTransaction<T>(
+  model: ModelCtor<Model>,
+  cb: (t: Transaction) => Promise<T>
+) {
+  return model.sequelize!.transaction(cb);
+}


### PR DESCRIPTION
## Summary
- add Sequelize helper utilities for CRUD and pagination
- type Sequelize models to avoid `any`
- refactor TagService to drop Base class usage

## Testing
- `npm run build` *(fails: Cannot find module 'express' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_684c47213f5c832b9c50470994ede013