### PR TITLE
Add typings to server models

### DIFF
--- a/server/src/features/media/model.ts
+++ b/server/src/features/media/model.ts
@@ -4,9 +4,37 @@ import { getUUIDv7 } from "@helpers";
 import { MEDIA_TABLE_NAME } from "./constants";
 import { EMediaType, EAccessLevel } from "@definitions/enums";
 import { IMedia } from "@/definitions/types";
-type MediaAttributes = Omit<IMedia, "createdAt" | "updatedAt" | "deletedAt" | "path" | "publicUrl" | "publicUrlExpiresAt">;
 
-export class Media extends Model<MediaAttributes, MediaAttributes> {}
+type MediaAttributes = Omit<
+  IMedia,
+  "createdAt" | "updatedAt" | "deletedAt" | "path" | "publicUrl" | "publicUrlExpiresAt"
+>;
+
+export class Media extends Model<MediaAttributes, MediaAttributes> {
+  declare id: string;
+  declare type: EMediaType;
+  declare url: string;
+  declare name: string;
+  declare caption?: string | null;
+  declare thumbnail?: string | null;
+  declare size?: number | null;
+  declare mimeType?: string | null;
+  declare duration?: number | null;
+  declare uploader: string;
+  declare storage: {
+    provider: string;
+    bucket: string;
+    metadata: Record<string, any>;
+  };
+  declare access: EAccessLevel;
+  declare metadata: Record<string, any>;
+  declare publicUrl?: string;
+  declare publicUrlExpiresAt?: Date;
+  declare path?: string;
+  declare createdAt: Date;
+  declare updatedAt: Date;
+  declare deletedAt?: Date;
+}
 
 Media.init(
   {

--- a/server/src/features/messages/model.ts
+++ b/server/src/features/messages/model.ts
@@ -3,9 +3,24 @@ import { DataTypes, Model } from "sequelize";
 import { getUUIDv7 } from "@helpers";
 import { MESSAGE_TABLE_NAME } from "./constants";
 import { IMessage } from "@/definitions/types";
-type MessageAttributes = Omit<IMessage, "createdAt" | "updatedAt" | "deletedAt" | "user" | "reactions">;
+type MessageAttributes = Omit<
+  IMessage,
+  "createdAt" | "updatedAt" | "deletedAt" | "user" | "reactions"
+>;
 
-export class Message extends Model<MessageAttributes, MessageAttributes> {}
+export class Message extends Model<MessageAttributes, MessageAttributes> {
+  declare id: string;
+  declare userId: string;
+  declare parentId: string | null;
+  declare content: IMessage["content"];
+  declare isEdited: boolean;
+  declare threadId: string;
+  declare createdAt: Date;
+  declare updatedAt: Date;
+  declare deletedAt?: Date;
+  declare user?: any;
+  declare reactions?: any[];
+}
 
 Message.init(
   {

--- a/server/src/features/reactions/model.ts
+++ b/server/src/features/reactions/model.ts
@@ -3,9 +3,20 @@ import { DataTypes, Model } from "sequelize";
 import { getUUIDv7 } from "@helpers";
 import { REACTION_TABLE_NAME } from "./constants";
 import { IReaction } from "@/definitions/types";
-type ReactionAttributes = Omit<IReaction, "createdAt" | "updatedAt" | "deletedAt">;
+type ReactionAttributes = Omit<
+  IReaction,
+  "createdAt" | "updatedAt" | "deletedAt"
+>;
 
-export class Reaction extends Model<ReactionAttributes, ReactionAttributes> {}
+export class Reaction extends Model<ReactionAttributes, ReactionAttributes> {
+  declare id: string;
+  declare contentId: string;
+  declare emoji: string;
+  declare userId: string;
+  declare createdAt: Date;
+  declare updatedAt: Date;
+  declare deletedAt?: Date;
+}
 
 Reaction.init(
   {

--- a/server/src/features/tags/model.ts
+++ b/server/src/features/tags/model.ts
@@ -5,7 +5,20 @@ import { TAG_TABLE_NAME } from "./constants";
 import { ITag } from "@/definitions/types";
 type TagAttributes = Omit<ITag, "createdAt" | "updatedAt" | "deletedAt">;
 
-export class Tag extends Model<TagAttributes, TagAttributes> {}
+export class Tag extends Model<TagAttributes, TagAttributes> {
+  declare id: string;
+  declare name: string;
+  declare value: string;
+  declare description?: string | null;
+  declare icon?: string | null;
+  declare color?: string | null;
+  declare parentId?: string | null;
+  declare createdBy?: string | null;
+  declare eventId?: string | null;
+  declare createdAt: Date;
+  declare updatedAt: Date;
+  declare deletedAt?: Date;
+}
 
 Tag.init(
   {

--- a/server/src/features/threads/model.ts
+++ b/server/src/features/threads/model.ts
@@ -4,9 +4,25 @@ import { getUUIDv7 } from "@helpers";
 import { THREAD_TABLE_NAME } from "./constants";
 import { EThreadType, EAccessLevel } from "@definitions/enums";
 import { IBaseThread } from "@/definitions/types";
-type ThreadAttributes = Omit<IBaseThread, "createdAt" | "updatedAt" | "deletedAt" | "messages">;
 
-export class Thread extends Model<ThreadAttributes, ThreadAttributes> {}
+type ThreadAttributes = Omit<
+  IBaseThread,
+  "createdAt" | "updatedAt" | "deletedAt" | "messages"
+>;
+
+export class Thread extends Model<ThreadAttributes, ThreadAttributes> {
+  declare id: string;
+  declare type: EThreadType;
+  declare status: EAccessLevel;
+  declare visibility: EAccessLevel;
+  declare parentId?: string | null;
+  declare eventId: string;
+  declare lockHistory: Record<string, any>[];
+  declare createdAt: Date;
+  declare updatedAt: Date;
+  declare deletedAt?: Date;
+  declare messages?: any[];
+}
 
 Thread.init(
   {

--- a/server/src/features/users/model.ts
+++ b/server/src/features/users/model.ts
@@ -3,12 +3,31 @@ import { DataTypes, Model } from "sequelize";
 import { getUUIDv7 } from "@helpers";
 import { USER_TABLE_NAME } from "./constants";
 import { IBaseUser } from "@/definitions/types";
-type UserAttributes = Omit<IBaseUser, "createdAt" | "updatedAt" | "deletedAt" | "media" | "profilePic"> & {
+type UserAttributes = Omit<
+  IBaseUser,
+  "createdAt" | "updatedAt" | "deletedAt" | "media" | "profilePic"
+> & {
   profilePic: Record<string, any> | null;
   media?: any;
 };
 
-export class User extends Model<UserAttributes, UserAttributes> {}
+export class User extends Model<UserAttributes, UserAttributes> {
+  declare id: string;
+  declare name: string;
+  declare email: string;
+  declare gender: string;
+  declare address: Record<string, any> | null;
+  declare isVerified: boolean;
+  declare profilePic: Record<string, any> | null;
+  declare mediaId: string | null;
+  declare username?: string;
+  declare password: string | null;
+  declare meta: Record<string, any>;
+  declare createdAt: Date;
+  declare updatedAt: Date;
+  declare deletedAt?: Date;
+  declare media?: any;
+}
 
 User.init(
   {


### PR DESCRIPTION
## Summary
- add TypeScript field declarations for Media, Message, Reaction, Thread, Tag and User models to match Event model style

## Testing
- `npm run build` *(fails: Cannot find module 'cors' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_684c57882970832baa9947df1334b669