### PR TITLE
Implement realtime socket events across app

### DIFF
--- a/client/contexts/Socket.tsx
+++ b/client/contexts/Socket.tsx
@@ -1,30 +1,24 @@
 // context/SocketContext.tsx
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useContext, useEffect } from "react";
 import SocketManager from "../common/socket";
 
-const SocketContext = createContext<typeof SocketManager | null>(null);
+const socketInstance = SocketManager.getInstance();
+const SocketContext = createContext<typeof SocketManager>(socketInstance);
 
 export const SocketProvider = ({ session, children }: { session: string; children: React.ReactNode }) => {
-  const [socket, setSocket] = useState<typeof SocketManager | null>(null);
-
   useEffect(() => {
     if (!session) return;
 
-    SocketManager.connect(session);
-    setSocket(SocketManager);
+    socketInstance.connect(session);
 
     return () => {
-      SocketManager.disconnect();
-      setSocket(null);
+      socketInstance.disconnect();
     };
   }, [session]);
 
-  return <SocketContext.Provider value={socket}>{children}</SocketContext.Provider>;
+  return <SocketContext.Provider value={socketInstance}>{children}</SocketContext.Provider>;
 };
 
 export const useSocket = () => {
-  const socket = useContext(SocketContext);
-
-  if (!socket) throw new Error("useSocket must be used within SocketProvider");
-  return socket;
+  return useContext(SocketContext);
 };

--- a/client/hooks/useSocketListener.ts
+++ b/client/hooks/useSocketListener.ts
@@ -1,0 +1,19 @@
+import { useEffect } from "react";
+import { useSocket } from "@/contexts/Socket";
+
+const useSocketListener = (
+  event: string,
+  handler: (...args: any[]) => void
+) => {
+  const socket = useSocket();
+
+  useEffect(() => {
+    if (!socket) return;
+    socket.on(event, handler);
+    return () => {
+      socket.off(event, handler);
+    };
+  }, [socket, event, handler]);
+};
+
+export default useSocketListener;

--- a/client/screens/Profile/index.tsx
+++ b/client/screens/Profile/index.tsx
@@ -18,6 +18,8 @@ import { AVATAR_BUCKET } from "@/constants/global";
 import { updateUser } from "@/common/api/user.action";
 import { SpinningLoader } from "@/components/ui/Loaders";
 import { formatDateToLongString } from "@/utils/date.utils";
+import useSocketListener from "@/hooks/useSocketListener";
+import { PLATFORM_SOCKET_EVENTS } from "@/constants/global";
 
 const Profile = () => {
   const { user, updateUser: updateUserContext } = useAuth();
@@ -32,6 +34,11 @@ const Profile = () => {
   const defaultTab = tab || "info";
 
   const [isUploading, setIsUploading] = useState(false);
+
+  useSocketListener(PLATFORM_SOCKET_EVENTS.USER_UPDATED, ({ data }) => {
+    if (!data || data.id !== user.id) return;
+    updateUserContext(data);
+  });
 
   const tabs = [
     {

--- a/server/src/socket/emitter.ts
+++ b/server/src/socket/emitter.ts
@@ -1,0 +1,15 @@
+import { Namespace } from "socket.io";
+
+let namespace: Namespace | null = null;
+
+export const setPlatformNamespace = (ns: Namespace) => {
+  namespace = ns;
+};
+
+export const emitSocketEvent = (
+  event: string,
+  payload: { data?: any; error?: any }
+) => {
+  if (!namespace) return;
+  namespace.emit(event, payload);
+};


### PR DESCRIPTION
## Summary
- fix socket context initialization
- add emitter to break socket circular deps
- emit partial updates for server events
- add realtime thread and user listeners on the client
- support populated fetches from event service
- add populate options for thread and message services

## Testing
- `npm run build` in `server` *(fails: Cannot find module 'express' or its corresponding type declarations)*
- `npm run build` in `client` *(fails: Missing script: "build")*

------
https://chatgpt.com/codex/tasks/task_b_684f971d1914832b80c1ff9406e95704