### PR TITLE
Add Swagger docs server and route annotations

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -35,7 +35,9 @@
     "ua-parser-js": "^2.0.3",
     "uuid": "^11.1.0",
     "winston": "^3.17.0",
-    "winston-daily-rotate-file": "^5.0.0"
+    "winston-daily-rotate-file": "^5.0.0",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^4.7.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.1",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,6 +1,7 @@
 import cors from "cors";
 import express from "express";
 import cookieparser from "cookie-parser";
+import swaggerUI from "swagger-ui-express";
 
 import helmet from "helmet";
 import config from "@config";
@@ -11,6 +12,7 @@ import {
 } from "@middlewares";
 import appRoutes from "@routes";
 import { NotFoundError } from "@exceptions";
+import { swaggerSpec } from "@docs/swagger";
 
 const createServer = () => {
   const app = express();
@@ -34,15 +36,8 @@ const createServer = () => {
 
   // routes setup
 
-  // // swagger docs
-  // // load yaml file
-  // const openapiYamlFile = fs.readFileSync(
-  //   __dirname + "/docs/openapi.yaml",
-  //   "utf8"
-  // );
-  // const swaggerDocument = Yaml.parse(openapiYamlFile);
-
-  // app.use("/docs", swaggerUI.serve, swaggerUI.setup(swaggerDocument));
+  // swagger docs
+  app.use("/docs", swaggerUI.serve, swaggerUI.setup(swaggerSpec));
 
   app.get("/", (req, res) => {
     res.send({

--- a/server/src/docs/swagger.ts
+++ b/server/src/docs/swagger.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from 'url';
+import path, { dirname } from 'path';
+import swaggerJsdoc from 'swagger-jsdoc';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export const swaggerOptions = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Bhandara API',
+      version: '1.0.0',
+    },
+    servers: [{ url: '/api' }],
+  },
+  apis: [path.join(__dirname, '../routes/**/*.ts')],
+};
+
+export const swaggerSpec = swaggerJsdoc(swaggerOptions);

--- a/server/src/routes/auth.route.ts
+++ b/server/src/routes/auth.route.ts
@@ -1,4 +1,16 @@
 import { Router } from "express";
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     AuthResponse:
+ *       type: object
+ *       properties:
+ *         success:
+ *           type: boolean
+ *         data:
+ *           type: object
+ */
 import {
   logOut,
   session,
@@ -15,16 +27,129 @@ import { sessionParser, userParser, asyncHandler } from "@middlewares";
 
 const router = Router();
 
+/**
+ * @openapi
+ * /auth/login:
+ *   post:
+ *     tags: [Auth]
+ *     summary: User login
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Login success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthResponse'
+ */
 router.post("/login", asyncHandler(login));
+/**
+ * @openapi
+ * /auth/google/callback:
+ *   get:
+ *     tags: [Auth]
+ *     summary: Google OAuth callback
+ *     responses:
+ *       200:
+ *         description: OAuth success
+ */
 router.get("/google/callback", asyncHandler(googleCallback));
+/**
+ * @openapi
+ * /auth/google:
+ *   get:
+ *     tags: [Auth]
+ *     summary: Redirect to Google OAuth
+ *     responses:
+ *       302:
+ *         description: Redirect
+ */
 router.get("/google", asyncHandler(googleAuth));
+/**
+ * @openapi
+ * /auth/signup:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Sign up user
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               email:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Signup success
+ */
 router.post("/signup", asyncHandler(signUp));
+/**
+ * @openapi
+ * /auth/oauth/signin-with-id-token:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Signin with OAuth id token
+ *     responses:
+ *       200:
+ *         description: Signin success
+ */
 router.post("/oauth/signin-with-id-token", asyncHandler(signInWithIdToken));
 
 router.use([sessionParser, userParser]);
+/**
+ * @openapi
+ * /auth/logout:
+ *   get:
+ *     tags: [Auth]
+ *     summary: Logout user
+ *     responses:
+ *       200:
+ *         description: Logged out
+ */
 router.get("/logout", asyncHandler(logOut));
+/**
+ * @openapi
+ * /auth/session:
+ *   get:
+ *     tags: [Auth]
+ *     summary: Get current session
+ */
 router.get("/session", asyncHandler(session));
+/**
+ * @openapi
+ * /auth/session/{sessionId}:
+ *   delete:
+ *     tags: [Auth]
+ *     summary: Delete session
+ *     parameters:
+ *       - in: path
+ *         name: sessionId
+ *         required: true
+ *         schema:
+ *           type: string
+ */
 router.delete("/session/:sessionId", asyncHandler(deleteSession));
+/**
+ * @openapi
+ * /auth/sessions:
+ *   get:
+ *     tags: [Auth]
+ *     summary: List sessions
+ */
 router.get("/sessions", asyncHandler(sessionsList));
 
 export default router;

--- a/server/src/routes/events.route.ts
+++ b/server/src/routes/events.route.ts
@@ -1,3 +1,25 @@
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     Event:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         name:
+ *           type: string
+ *         description:
+ *           type: string
+ *         location:
+ *           type: object
+ *         status:
+ *           type: string
+ *         tags:
+ *           type: array
+ *           items:
+ *             type: object
+ */
 import { Router } from "express";
 import {
   asyncHandler,
@@ -22,47 +44,235 @@ import {
 } from "@features/events/controller";
 const router = Router();
 
+/**
+ * @openapi
+ * /events:
+ *   get:
+ *     tags: [Events]
+ *     summary: List events
+ *   post:
+ *     tags: [Events]
+ *     summary: Create event
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Event'
+ */
 router.use([sessionParser, userParser]);
 
 router.route("/").get(asyncHandler(getEvents)).post(asyncHandler(createEvent));
 
 router
   .route("/:eventId")
+  /**
+   * @openapi
+   * /events/{eventId}:
+   *   get:
+   *     tags: [Events]
+   *     summary: Get event by ID
+   *     parameters:
+   *       - in: path
+   *         name: eventId
+   *         required: true
+   *         schema:
+   *           type: string
+   *   put:
+   *     tags: [Events]
+   *     summary: Update event
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             $ref: '#/components/schemas/Event'
+   *   delete:
+   *     tags: [Events]
+   *     summary: Delete event
+   */
   .get([validateParams(["eventId"])], asyncHandler(getEventById))
   .put([validateParams(["eventId"])], asyncHandler(updateEvent))
   .delete([validateParams(["eventId"])], asyncHandler(deleteEvent));
 
+/**
+ * @openapi
+ * /events/{eventId}/tags/{tagId}/associate:
+ *   post:
+ *     tags: [Events]
+ *     summary: Associate tag to event
+ *     parameters:
+ *       - in: path
+ *         name: eventId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: tagId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       201:
+ *         description: Tag associated
+ */
 router.post(
   "/:eventId/tags/:tagId/associate",
   [validateParams(["eventId", "tagId"])],
   asyncHandler(createEventTag)
 );
 
+/**
+ * @openapi
+ * /events/{eventId}/tags/{tagId}:
+ *   delete:
+ *     tags: [Events]
+ *     summary: Remove tag from event
+ *     parameters:
+ *       - in: path
+ *         name: eventId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: tagId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Tag removed
+ */
 router.delete(
   "/:eventId/tags/:tagId",
   [validateParams(["eventId", "tagId"])],
   asyncHandler(deleteEventTag)
 );
 
+/**
+ * @openapi
+ * /events/{eventId}/threads:
+ *   get:
+ *     tags: [Events]
+ *     summary: Get threads for event
+ *     parameters:
+ *       - in: path
+ *         name: eventId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: List of threads
+ */
 router.get(
   "/:eventId/threads",
   [validateParams(["eventId"])],
   asyncHandler(getEventThreads)
 );
 
+/**
+ * @openapi
+ * /events/{eventId}/verify:
+ *   post:
+ *     tags: [Events]
+ *     summary: Verify event attendance
+ *     parameters:
+ *       - in: path
+ *         name: eventId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               currentCoordinates:
+ *                 type: object
+ *     responses:
+ *       200:
+ *         description: Verification result
+ */
 router.post("/:eventId/verify", asyncHandler(verifyEvent));
+/**
+ * @openapi
+ * /events/{eventId}/{action}:
+ *   get:
+ *     tags: [Events]
+ *     summary: Join or leave event
+ *     parameters:
+ *       - in: path
+ *         name: eventId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: action
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: [join, leave]
+ *     responses:
+ *       200:
+ *         description: Join/leave status
+ */
 router.get(
   "/:eventId/:action",
   [validateParams(["eventId", "action"])],
   asyncHandler(eventJoinLeaveHandler)
 );
 
+/**
+ * @openapi
+ * /events/{eventId}/media/{mediaId}/associate:
+ *   get:
+ *     tags: [Events]
+ *     summary: Associate media with event
+ *     parameters:
+ *       - in: path
+ *         name: eventId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: mediaId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Media associated
+ */
 router.get(
   "/:eventId/media/:mediaId/associate",
   [validateParams(["eventId", "mediaId"])],
   asyncHandler(associateEventMedia)
 );
 
+/**
+ * @openapi
+ * /events/{eventId}/media/{mediaId}:
+ *   delete:
+ *     tags: [Events]
+ *     summary: Delete event media
+ *     parameters:
+ *       - in: path
+ *         name: eventId
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: mediaId
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Media deleted
+ */
 router.delete(
   "/:eventId/media/:mediaId",
   [validateParams(["eventId", "mediaId"])],

--- a/server/src/routes/media.route.ts
+++ b/server/src/routes/media.route.ts
@@ -7,6 +7,18 @@ import {
   getMediaPublicUrl,
   getMediaPublicUrls,
 } from "@features/media/controller";
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     Media:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         url:
+ *           type: string
+ */
 import { asyncHandler, sessionParser, userParser } from "@middlewares";
 import { Router } from "express";
 
@@ -14,15 +26,56 @@ const router = Router({ mergeParams: true });
 
 router.use([sessionParser, userParser]);
 
+/**
+ * @openapi
+ * /media/public-urls:
+ *   get:
+ *     tags: [Media]
+ *     summary: Get public URLs for media
+ */
 router.get("/public-urls", asyncHandler(getMediaPublicUrls));
+/**
+ * @openapi
+ * /media/upload:
+ *   post:
+ *     tags: [Media]
+ *     summary: Upload file
+ */
 router.post("/upload", asyncHandler(uploadFile));
+/**
+ * @openapi
+ * /media/get-signed-upload-url:
+ *   post:
+ *     tags: [Media]
+ *     summary: Get signed upload URL
+ */
 router.post("/get-signed-upload-url", asyncHandler(getSignedUploadUrl));
 router
   .route("/:mediaId")
+  /**
+   * @openapi
+   * /media/{mediaId}:
+   *   delete:
+   *     tags: [Media]
+   *     summary: Delete media
+   *   get:
+   *     tags: [Media]
+   *     summary: Get media by ID
+   *   patch:
+   *     tags: [Media]
+   *     summary: Update media
+   */
   .delete(asyncHandler(deleteFile))
   .get(asyncHandler(getMediaById))
   .patch(asyncHandler(updateMedia));
 
+/**
+ * @openapi
+ * /media/public-url:
+ *   post:
+ *     tags: [Media]
+ *     summary: Get public URL for a media file
+ */
 router.post("/public-url", asyncHandler(getMediaPublicUrl));
 
 export default router;

--- a/server/src/routes/tags.route.ts
+++ b/server/src/routes/tags.route.ts
@@ -1,3 +1,17 @@
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     Tag:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         name:
+ *           type: string
+ *         value:
+ *           type: string
+ */
 import { Router } from "express";
 import { sessionParser, userParser, asyncHandler } from "@middlewares";
 import {
@@ -13,14 +27,62 @@ const router = Router();
 
 router.use([sessionParser, userParser]);
 
+/**
+ * @openapi
+ * /tags:
+ *   get:
+ *     tags: [Tags]
+ *     summary: List tags
+ *   post:
+ *     tags: [Tags]
+ *     summary: Create tag
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Tag'
+ */
 router.get("/", asyncHandler(getTags));
 router.post("/", asyncHandler(createTag));
 router
   .route("/:tagId")
+  /**
+   * @openapi
+   * /tags/{tagId}:
+   *   get:
+   *     tags: [Tags]
+   *     summary: Get tag by ID
+   *     parameters:
+   *       - in: path
+   *         name: tagId
+   *         required: true
+   *         schema:
+   *           type: string
+   *   put:
+   *     tags: [Tags]
+   *     summary: Update tag
+   *   delete:
+   *     tags: [Tags]
+   *     summary: Delete tag
+   */
   .get(asyncHandler(getTagById))
   .put(asyncHandler(updateTag))
   .delete(asyncHandler(deleteTag));
 
+/**
+ * @openapi
+ * /tags/{tagId}/sub-tags:
+ *   get:
+ *     tags: [Tags]
+ *     summary: Get sub tags
+ *     parameters:
+ *       - in: path
+ *         name: tagId
+ *         required: true
+ *         schema:
+ *           type: string
+ */
 router.get("/:tagId/sub-tags", asyncHandler(getSubTags));
 
 export default router;

--- a/server/src/routes/test.route.ts
+++ b/server/src/routes/test.route.ts
@@ -1,3 +1,9 @@
+/**
+ * @openapi
+ * tags:
+ *   name: Test
+ *   description: Test routes
+ */
 import { supabase } from "@connections";
 import { RequestContext } from "@contexts";
 import { ICustomRequest } from "@definitions/types";
@@ -10,6 +16,13 @@ const router = Router();
 const redisCache = new RedisCache({ namespace: "test" });
 const userService = new UserService();
 
+/**
+ * @openapi
+ * /test/:
+ *   get:
+ *     tags: [Test]
+ *     summary: Test endpoint
+ */
 router.get("/", [userParser], async (req, res) => {
   const redisData = await getUserSessionCacheList(req.user.id);
   res.json({ redisData });
@@ -20,5 +33,12 @@ router.get(
   [sessionParser, userParser],
   async (req: ICustomRequest, res: Response) => {}
 );
+/**
+ * @openapi
+ * /test/user:
+ *   get:
+ *     tags: [Test]
+ *     summary: Dummy user route
+ */
 
 export default router;

--- a/server/src/routes/threads.route.ts
+++ b/server/src/routes/threads.route.ts
@@ -1,3 +1,24 @@
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     Thread:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         eventId:
+ *           type: string
+ *         type:
+ *           type: string
+ *     Message:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         content:
+ *           type: object
+ */
 import { Router } from "express";
 import {
   asyncHandler,
@@ -26,10 +47,33 @@ const router = Router();
 
 router.use([sessionParser, userParser]);
 
+/**
+ * @openapi
+ * /threads:
+ *   get:
+ *     tags: [Threads]
+ *     summary: List threads
+ *   post:
+ *     tags: [Threads]
+ *     summary: Create thread
+ */
 router.get("/", [paginationParser], asyncHandler(getThreads));
 router.post("/", asyncHandler(createThread));
 router
   .route("/:threadId")
+  /**
+   * @openapi
+   * /threads/{threadId}:
+   *   get:
+   *     tags: [Threads]
+   *     summary: Get thread
+   *   put:
+   *     tags: [Threads]
+   *     summary: Update thread
+   *   delete:
+   *     tags: [Threads]
+   *     summary: Delete thread
+   */
   .get(asyncHandler(getThread))
   .put(asyncHandler(updateThread))
   .delete(asyncHandler(deleteThread));
@@ -39,9 +83,36 @@ router.get(
   [paginationParser],
   asyncHandler(getMessages)
 );
+/**
+ * @openapi
+ * /threads/{threadId}/messages:
+ *   get:
+ *     tags: [Threads]
+ *     summary: List messages
+ */
+/**
+ * @openapi
+ * /threads/{threadId}/messages:
+ *   post:
+ *     tags: [Threads]
+ *     summary: Create message
+ */
 router.post("/:threadId/messages", asyncHandler(createMessage));
 router
   .route("/:threadId/messages/:messageId")
+  /**
+   * @openapi
+   * /threads/{threadId}/messages/{messageId}:
+   *   get:
+   *     tags: [Threads]
+   *     summary: Get message
+   *   put:
+   *     tags: [Threads]
+   *     summary: Update message
+   *   delete:
+   *     tags: [Threads]
+   *     summary: Delete message
+   */
   .get(asyncHandler(getMessageById))
   .put(asyncHandler(updateMessage))
   .delete(asyncHandler(deleteMessage));
@@ -51,5 +122,12 @@ router.get(
   [paginationParser],
   asyncHandler(getChildMessages)
 );
+/**
+ * @openapi
+ * /threads/{threadId}/child-messages/{parentId}:
+ *   get:
+ *     tags: [Threads]
+ *     summary: Get child messages
+ */
 
 export default router;

--- a/server/src/routes/users.route.ts
+++ b/server/src/routes/users.route.ts
@@ -1,3 +1,22 @@
+/**
+ * @openapi
+ * components:
+ *   schemas:
+ *     User:
+ *       type: object
+ *       properties:
+ *         id:
+ *           type: string
+ *         name:
+ *           type: string
+ *         email:
+ *           type: string
+ *         username:
+ *           type: string
+ *         profilePic:
+ *           type: object
+ *           nullable: true
+ */
 import {
   asyncHandler,
   paginationParser,
@@ -16,18 +35,135 @@ import {
 
 const router = Router();
 
+/**
+ * @openapi
+ * /users/query:
+ *   get:
+ *     tags: [Users]
+ *     summary: Find user by email or username
+ *     parameters:
+ *       - in: query
+ *         name: email
+ *         schema:
+ *           type: string
+ *       - in: query
+ *         name: username
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Success
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 data:
+ *                   $ref: '#/components/schemas/User'
+ *                 error:
+ *                   nullable: true
+ */
 router.get("/query", asyncHandler(getUserByQuery));
 
 router.use([sessionParser, userParser]);
 
+/**
+ * @openapi
+ * /users:
+ *   get:
+ *     tags: [Users]
+ *     summary: List users
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Paginated users
+ */
 router.get("/", paginationParser, asyncHandler(getAllUser));
 
 router
   .route("/:id")
+  /**
+   * @openapi
+   * /users/{id}:
+   *   get:
+   *     tags: [Users]
+   *     summary: Get user by ID
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: Success
+   */
   .get(asyncHandler(getUserById))
+  /**
+   * @openapi
+   * /users/{id}:
+   *   delete:
+   *     tags: [Users]
+   *     summary: Delete user
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *     responses:
+   *       200:
+   *         description: Deleted
+   */
   .delete(asyncHandler(deleteUser))
+  /**
+   * @openapi
+   * /users/{id}:
+   *   patch:
+   *     tags: [Users]
+   *     summary: Update user
+   *     parameters:
+   *       - in: path
+   *         name: id
+   *         required: true
+   *         schema:
+   *           type: string
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *     responses:
+   *       200:
+   *         description: Updated
+   */
   .patch(asyncHandler(updateUser));
 
+/**
+ * @openapi
+ * /users/{id}/interests:
+ *   get:
+ *     tags: [Users]
+ *     summary: Get user interests
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: List of interests
+ */
 router.get("/:id/interests", asyncHandler(getUserInterests));
 
 export default router;


### PR DESCRIPTION
## Summary
- add swagger-jsdoc and swagger-ui-express dependencies
- configure Swagger server in `app.ts`
- generate spec from JSDoc comments via `swagger.ts`
- document API endpoints directly in route files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686232459614832b82040847cf522a0a