### PR TITLE
Implement verify event modal

### DIFF
--- a/client/common/api/events.action.ts
+++ b/client/common/api/events.action.ts
@@ -54,3 +54,13 @@ export const getUserEvents = async (
   );
   return res.data;
 };
+
+export const verifyEvent = async (
+  eventId: string,
+  currentCoordinates: { latitude: number; longitude: number }
+): Promise<IBaseResponse<boolean>> => {
+  const res = await axiosClient.post(`/events/${eventId}/verify`, {
+    currentCoordinates
+  });
+  return res.data;
+};

--- a/client/components/VerifyEvent.tsx
+++ b/client/components/VerifyEvent.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from "react";
+import { IEvent, IBaseUser } from "@/definitions/types";
+import { useAuth } from "@/contexts/AuthContext";
+import { OutlineButton, FilledButton } from "@/components/ui/Buttons";
+import { CardWrapper } from "@/components/ui/common-styles";
+import { H6, Text, View } from "tamagui";
+import { useDialog } from "@/hooks/useModal";
+import VerificationMap from "@/components/maps/VerificationMap";
+import { EVENT_VERIFY_RADIUS_M } from "@/constants/global";
+import { haversineDistanceInM } from "@/utils/location";
+import { verifyEvent } from "@/common/api/events.action";
+import { useToastController } from "@tamagui/toast";
+import { Check } from "@tamagui/lucide-icons";
+import CustomTooltip from "@/components/CustomTooltip";
+import { formatDateWithTimeString } from "@/utils/date.utils";
+import { SpinningLoader } from "@/components/ui/Loaders";
+
+const VerifyEvent = ({
+  event,
+  onVerified
+}: {
+  event: IEvent;
+  onVerified: (verifier: { user: IBaseUser; verifiedAt: string }) => void;
+}) => {
+  const { user } = useAuth();
+  const isCreator = user?.id === event.createdBy;
+  const existingVerifier = event.verifiers.find((v) => {
+    const id = typeof v.user === "string" ? v.user : v.user.id;
+    return id === user?.id;
+  });
+
+  const { open, close, RenderContent } = useDialog();
+  const toast = useToastController();
+  const [userCoords, setUserCoords] = useState<[number, number] | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  if (isCreator) return null;
+
+  const canVerify =
+    userCoords &&
+    haversineDistanceInM(
+      { latitude: userCoords[1], longitude: userCoords[0] },
+      { latitude: event.location.latitude!, longitude: event.location.longitude! }
+    ) <= EVENT_VERIFY_RADIUS_M;
+
+  const handleVerify = async () => {
+    if (!userCoords) return;
+    setIsSubmitting(true);
+    try {
+      await verifyEvent(event.id, {
+        latitude: userCoords[1],
+        longitude: userCoords[0]
+      });
+      onVerified({ user: user as IBaseUser, verifiedAt: new Date().toISOString() });
+      close();
+    } catch (error: any) {
+      toast.show(error?.message || "Failed to verify");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const button = existingVerifier ? (
+    <CustomTooltip
+      trigger={
+        <OutlineButton size="medium" width="auto" disabled>
+          <Check size={16} />
+          <Text>Verified</Text>
+        </OutlineButton>
+      }
+    >
+      <CardWrapper rounded="$3" p="$2">
+        <Text fontSize="$2">
+          Verified at {formatDateWithTimeString(existingVerifier.verifiedAt as any)}
+        </Text>
+      </CardWrapper>
+    </CustomTooltip>
+  ) : (
+    <OutlineButton size="medium" width="auto" onPress={open} px="$2">
+      <Check size={16} />
+      <Text>Verify Event</Text>
+    </OutlineButton>
+  );
+
+  return (
+    <>
+      {button}
+      <RenderContent>
+        <CardWrapper gap="$4" width={300}>
+          <H6>Verify Attendance</H6>
+          <View height={200} width="100%">
+            <VerificationMap
+              eventCoords={[event.location.longitude!, event.location.latitude!]}
+              radius={EVENT_VERIFY_RADIUS_M}
+              onUserLocationChange={setUserCoords}
+            />
+          </View>
+          <FilledButton
+            size="medium"
+            disabled={!canVerify || isSubmitting}
+            onPress={handleVerify}
+            iconAfter={isSubmitting ? <SpinningLoader /> : undefined}
+          >
+            Verify Now
+          </FilledButton>
+        </CardWrapper>
+      </RenderContent>
+    </>
+  );
+};
+
+export default VerifyEvent;

--- a/client/components/maps/VerificationMap.tsx
+++ b/client/components/maps/VerificationMap.tsx
@@ -1,0 +1,67 @@
+import { StyleSheet } from "react-native";
+import Mapbox, { MapView, Camera, UserLocation, PointAnnotation, ShapeSource, FillLayer } from "@rnmapbox/maps";
+import config from "@/config";
+import { useRef } from "react";
+
+Mapbox.setAccessToken(config.mapbox.accessToken);
+Mapbox.setTelemetryEnabled(false);
+
+const styles = StyleSheet.create({
+  map: { flex: 1, width: "100%", height: "100%" }
+});
+
+function generateCircleCoords(
+  center: [number, number],
+  radius: number,
+  points = 64
+) {
+  const [lng, lat] = center;
+  const coords = [] as [number, number][];
+  const distanceX = (radius / 111320) * Math.cos((lat * Math.PI) / 180);
+  const distanceY = radius / 110540;
+  for (let i = 0; i <= points; i++) {
+    const theta = (i / points) * (2 * Math.PI);
+    const x = lng + distanceX * Math.cos(theta);
+    const y = lat + distanceY * Math.sin(theta);
+    coords.push([x, y]);
+  }
+  return coords;
+}
+
+export default function VerificationMap({
+  eventCoords,
+  radius,
+  onUserLocationChange
+}: {
+  eventCoords: [number, number];
+  radius: number;
+  onUserLocationChange: (coords: [number, number]) => void;
+}) {
+  const circle = {
+    type: "Feature",
+    geometry: {
+      type: "Polygon",
+      coordinates: [generateCircleCoords(eventCoords, radius)]
+    }
+  } as const;
+
+  const cameraRef = useRef<Camera>(null);
+
+  const handleUserLocation = (loc: any) => {
+    onUserLocationChange([loc.coords.longitude, loc.coords.latitude]);
+  };
+
+  return (
+    <MapView style={styles.map} compassEnabled zoomEnabled>
+      <Camera ref={cameraRef} centerCoordinate={eventCoords} zoomLevel={17} />
+      <UserLocation visible showsUserHeadingIndicator onUpdate={handleUserLocation} />
+      <ShapeSource id="verify-circle" shape={circle}>
+        <FillLayer
+          id="verify-fill"
+          style={{ fillColor: "rgba(0,122,255,0.2)", fillOutlineColor: "rgba(0,122,255,0.5)" }}
+        />
+      </ShapeSource>
+      <PointAnnotation id="event-location" coordinate={eventCoords} />
+    </MapView>
+  );
+}

--- a/client/constants/global.ts
+++ b/client/constants/global.ts
@@ -3,6 +3,8 @@ export const BASE_AVATAR_URL = "https://cdn.jsdelivr.net/gh/alohe/avatars/png/me
 export const AVATAR_BUCKET = "avatars";
 export const EVENT_MEDIA_BUCKET = "event-files";
 
+export const EVENT_VERIFY_RADIUS_M = 50;
+
 export const PLATFORM_SOCKET_EVENTS = {
   JOIN_ROOM: "join:room",
   LEAVE_ROOM: "leave:room",

--- a/client/screens/EventDetails/index.tsx
+++ b/client/screens/EventDetails/index.tsx
@@ -23,6 +23,7 @@ import config from "@/config";
 import useSocketListener from "@/hooks/useSocketListener";
 import { PLATFORM_SOCKET_EVENTS } from "@/constants/global";
 import MapPreviewCard from "@/components/MapPreviewCard";
+import VerifyEvent from "@/components/VerifyEvent";
 import MessageCard from "./MessageView/MessageCard";
 import { IMessageViewAddMessageProp, IMessageViewBaseProps } from "./MessageView";
 import MessageViewSheetContent from "./MessageViewSheetContent";
@@ -324,6 +325,14 @@ const EventDetails: React.FC = () => {
                   </ProfileAvatarPreview>
                 )}
                 <MapPreviewCard {..._event.location} />
+                <VerifyEvent
+                  event={_event}
+                  onVerified={(v) =>
+                    setEvent((prev) =>
+                      prev ? { ...prev, verifiers: [...prev.verifiers, v] } : prev
+                    )
+                  }
+                />
                 <CardWrapper>
                   <H6>Tags</H6>
                   <TagListing tags={tags || []} />

--- a/client/screens/Home.tsx
+++ b/client/screens/Home.tsx
@@ -18,15 +18,17 @@ import React from "react";
 import { H5, Image, ScrollView, Text, XStack, YStack } from "tamagui";
 
 import { View } from "tamagui";
+import VerifyEvent from "@/components/VerifyEvent";
 
 const EventCard = ({ event }: { event: IEvent }) => {
-  const createdBy = event.creator as IBaseUser;
+  const [localEvent, setLocalEvent] = React.useState<IEvent>(event);
+  const createdBy = localEvent.creator as IBaseUser;
   const router = useRouter();
 
-  const previewEventImage = event.media.find((media) => media.type === EMediaType.Image)?.publicUrl;
+  const previewEventImage = localEvent.media.find((media) => media.type === EMediaType.Image)?.publicUrl;
 
   const handleImagePress = () => {
-    router.push(`/event/${event.id}`);
+    router.push(`/event/${localEvent.id}`);
   };
 
   return (
@@ -68,7 +70,7 @@ const EventCard = ({ event }: { event: IEvent }) => {
           bg={"rgba(0, 0, 0, 0.2)"}
           backdropFilter={"blur(8px)"}
         >
-          <H5>{event.name}</H5>
+            <H5>{localEvent.name}</H5>
           <XStack gap={"$4"}>
             <Badge>
               <XStack gap={"$2"}>
@@ -132,11 +134,11 @@ const EventCard = ({ event }: { event: IEvent }) => {
               transition={"color 0.2s ease-in-out"}
             />
           </View>
-          <Text fontSize={"$4"}>{event.location.street || "data not available"}</Text>
+          <Text fontSize={"$4"}>{localEvent.location.street || "data not available"}</Text>
         </XStack>
 
         <XStack
-          flex={+(typeof event.capacity === "number")}
+          flex={+(typeof localEvent.capacity === "number")}
           justify={"space-between"}
         >
           {/* organizer info */}
@@ -149,7 +151,7 @@ const EventCard = ({ event }: { event: IEvent }) => {
           </ProfileAvatarPreview>
 
           {/* capacity info */}
-          {typeof event.capacity === "number" && (
+          {typeof localEvent.capacity === "number" && (
             <XStack
               items={"center"}
               justify={"flex-end"}
@@ -161,11 +163,11 @@ const EventCard = ({ event }: { event: IEvent }) => {
                   fontSize={"$4"}
                   fontWeight={"bold"}
                 >
-                  {event.capacity}
+                  {localEvent.capacity}
                 </Text>
               </YStack>
               <CircularFillIndicator
-                percentage={event.participants.length / event.capacity}
+                percentage={localEvent.participants.length / localEvent.capacity}
                 size={30}
               />
             </XStack>
@@ -173,7 +175,7 @@ const EventCard = ({ event }: { event: IEvent }) => {
         </XStack>
 
         {/* verifiers */}
-        {!!event.verifiers.length && (
+        {!!localEvent.verifiers.length && (
           <YStack
             gap={"$2"}
             items={"flex-start"}
@@ -184,22 +186,22 @@ const EventCard = ({ event }: { event: IEvent }) => {
               width={"100%"}
               justify={"space-between"}
             >
-              <UserCluster users={event.verifiers.map((verifier) => verifier.user as IBaseUser)} />
+              <UserCluster users={localEvent.verifiers.map((verifier) => verifier.user as IBaseUser)} />
 
-              <OutlineButton
-                rounded={"$2"}
-                width={"auto"}
-                size={"medium"}
-                px={"$2"}
-              >
-                <Check size={16} />
-                <Text>Verify Event</Text>
-              </OutlineButton>
+              <VerifyEvent
+                event={localEvent}
+                onVerified={(v) =>
+                  setLocalEvent((prev) => ({
+                    ...prev,
+                    verifiers: [...prev.verifiers, v]
+                  }))
+                }
+              />
             </XStack>
           </YStack>
         )}
 
-        {!!event.tags.length && (
+        {!!localEvent.tags.length && (
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
@@ -208,7 +210,7 @@ const EventCard = ({ event }: { event: IEvent }) => {
               gap={"$2"}
               flexWrap={"wrap"}
             >
-              {event.tags.map((tag) => (
+              {localEvent.tags.map((tag) => (
                 <CustomTooltip
                   trigger={
                     <Badge


### PR DESCRIPTION
## Summary
- add event verification radius constant
- support verifying events via API
- build map view for verifying within radius
- create `VerifyEvent` component
- integrate verification in Event details screen and event cards

## Testing
- `yarn test` *(fails: package not in lockfile)*
- `yarn lint` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_6864c10d3dd8832b886f99f539ce328d