### PR TITLE
Add cloudinary file storage provider

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -34,6 +34,7 @@
     "socket.io": "^4.8.1",
     "ua-parser-js": "^2.0.3",
     "uuid": "^11.1.0",
+    "cloudinary": "^1.38.2",
     "winston": "^3.17.0",
     "winston-daily-rotate-file": "^5.0.0",
     "swagger-jsdoc": "^6.2.8",

--- a/server/src/cloudinary/index.ts
+++ b/server/src/cloudinary/index.ts
@@ -1,0 +1,82 @@
+import { v2 as cloudinary, UploadApiResponse, UploadApiOptions } from 'cloudinary';
+import config from '@/config';
+
+cloudinary.config({
+  cloud_name: config.cloudinary.cloudName,
+  api_key: config.cloudinary.apiKey,
+  api_secret: config.cloudinary.apiSecret,
+  secure: config.cloudinary.secure,
+});
+
+class CloudinaryService {
+  async uploadFile({
+    bucket,
+    path,
+    base64FileData,
+    mimeType,
+    options = {},
+  }: {
+    bucket: string;
+    path: string;
+    base64FileData: string;
+    mimeType: string;
+    options?: UploadApiOptions;
+  }): Promise<{ data: UploadApiResponse; error: any }> {
+    const fileData = `data:${mimeType};base64,${base64FileData}`;
+    try {
+      const res = await cloudinary.uploader.upload(fileData, {
+        folder: bucket,
+        public_id: path,
+        resource_type: 'auto',
+        ...options,
+      });
+      return { data: res, error: null };
+    } catch (error) {
+      return { data: null as any, error };
+    }
+  }
+
+  async deleteFile(publicId: string) {
+    try {
+      const res = await cloudinary.uploader.destroy(publicId, { invalidate: true });
+      return { data: res, error: null };
+    } catch (error) {
+      return { data: null as any, error };
+    }
+  }
+
+  getPublicUrl(publicId: string, options: Record<string, any> = {}) {
+    const url = cloudinary.url(publicId, { secure: true, ...options });
+    return { data: { signedUrl: url }, error: null };
+  }
+
+  getSignedUploadParams({ bucket, path }: { bucket: string; path: string }) {
+    const timestamp = Math.floor(Date.now() / 1000);
+    const paramsToSign: Record<string, any> = {
+      timestamp,
+      folder: bucket,
+      public_id: path,
+    };
+    const signature = cloudinary.utils.api_sign_request(
+      paramsToSign,
+      config.cloudinary.apiSecret
+    );
+
+    const url = `https://api.cloudinary.com/v1_1/${config.cloudinary.cloudName}/auto/upload`;
+    return {
+      data: {
+        url,
+        params: {
+          ...paramsToSign,
+          signature,
+          // Cloudinary API key is not a secret and is safe to expose
+          // in client side direct upload parameters
+          api_key: config.cloudinary.apiKey,
+        },
+      },
+      error: null,
+    };
+  }
+}
+
+export default CloudinaryService;

--- a/server/src/features/media/controller.ts
+++ b/server/src/features/media/controller.ts
@@ -9,13 +9,14 @@ import { get32BitMD5Hash } from "@helpers";
 const mediaService = new MediaService();
 
 export const uploadFile = async (req: ICustomRequest, res: Response) => {
-  const { file, path, bucket, mimeType, format, ...rest } = req.body;
+  const { file, path, bucket, mimeType, provider, format, ...rest } = req.body;
 
   const uploadPath = `${req.user.id}/${path}`;
   const uploadRes = (await mediaService.uploadFile({
     file,
     path: uploadPath,
     bucket,
+    provider,
     mimeType,
     options: {
       uploader: req.user.id,
@@ -30,12 +31,13 @@ export const getSignedUploadUrl = async (
   req: ICustomRequest,
   res: Response
 ) => {
-  const { path, bucket, mimeType, parentPath, format, ...rest } = req.body;
+  const { path, bucket, mimeType, provider, parentPath, format, ...rest } = req.body;
 
   const uploadPath = `${parentPath || req.user.id}/${path}`;
   const insertData = {
     path: uploadPath,
     bucket,
+    provider,
     mimeType,
     options: {
       uploader: req.user.id,
@@ -51,13 +53,14 @@ export const getSignedUploadUrl = async (
 };
 
 export const createMediaData = async (req: ICustomRequest, res: Response) => {
-  const { file, path, bucket, mimeType, format, ...rest } = req.body;
+  const { file, path, bucket, mimeType, provider, format, ...rest } = req.body;
 
   const uploadPath = `${req.user.id}/${path}`;
   const { data } = await mediaService.create({
     file,
     path: uploadPath,
     bucket,
+    provider,
     mimeType,
     options: {
       uploader: req.user.id,
@@ -87,8 +90,8 @@ export const getMediaById = async (req: ICustomRequest, res: Response) => {
 };
 
 export const getMediaPublicUrl = async (req: ICustomRequest, res: Response) => {
-  const { path, bucket } = req.body;
-  const signedUrl = await mediaService.getPublicUrl(path, bucket);
+  const { path, bucket, provider } = req.body;
+  const signedUrl = await mediaService.getPublicUrl(path, bucket, provider);
   if (isEmpty(signedUrl)) throw new NotFoundError("Media not found at path");
 
   return res.status(200).json(signedUrl);

--- a/server/src/features/media/validation.ts
+++ b/server/src/features/media/validation.ts
@@ -31,6 +31,12 @@ const mediaStorageSchema = {
 const mediaSchema = {
   type: "object",
   properties: {
+    provider: {
+      type: "string",
+      enum: ["local", "s3", "gcs", "cloudinary", "supabase"],
+      errorMessage:
+        "Provider must be one of 'local', 's3', 'gcs', 'cloudinary', or 'supabase'",
+    },
     path: {
       type: "string",
       errorMessage: "Upload path must be a valid string",
@@ -104,11 +110,12 @@ const mediaSchema = {
       },
     },
   },
-  required: ["path", "bucket", "mimeType", "options"],
+  required: ["provider", "path", "bucket", "mimeType", "options"],
   additionalProperties: false,
   errorMessage: {
     type: "Media data must be an object",
     required: {
+      provider: "Provider is required",
       path: "Path is required",
       bucket: "Bucket is required",
       mimeType: "MIME type is required",


### PR DESCRIPTION
## Summary
- add Cloudinary service implementation
- enable provider field in media validations
- support provider parameter in media controller routes
- make MediaService aware of cloudinary provider for uploads, deletions and URL generation
- include Cloudinary dependency
- use secure_url from Cloudinary upload result
- await Cloudinary public URL lookups
- document that Cloudinary API key is safe to expose
- refactor: make cloudinary public url sync

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'cors' or its corresponding type declarations)*


------
https://chatgpt.com/codex/tasks/task_b_6864c8521ad4832ba8f1b2d66dd279d9