### PR TITLE
Add spatial indexes for event location and user address

### DIFF
--- a/server/src/database/migrations/init/tables.sql
+++ b/server/src/database/migrations/init/tables.sql
@@ -1,6 +1,8 @@
 -- Enable UUID generation
 CREATE EXTENSION IF NOT EXISTS "pgcrypto";
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+-- Enable PostGIS for spatial functions
+CREATE EXTENSION IF NOT EXISTS postgis;
 
 -- Enums
 CREATE TYPE "ThreadType" AS ENUM ('discussion', 'qna');
@@ -170,3 +172,27 @@ CREATE TABLE "EventMedia" (
 COMMENT ON TABLE "EventMedia" IS 'Junction table for many-to-many relationship between Events and Media';
 COMMENT ON COLUMN "EventMedia"."eventId" IS 'ID of the event';
 COMMENT ON COLUMN "EventMedia"."mediaId" IS 'ID of the media';
+
+-- Spatial index on Events.location coordinates
+CREATE INDEX IF NOT EXISTS events_location_gix ON "Events"
+USING GIST (
+  ST_SetSRID(
+    ST_MakePoint(
+      CAST("location"->'coordinates'->>'longitude' AS DOUBLE PRECISION),
+      CAST("location"->'coordinates'->>'latitude' AS DOUBLE PRECISION)
+    ),
+    4326
+  )
+);
+
+-- Spatial index on Users.address coordinates
+CREATE INDEX IF NOT EXISTS users_address_gix ON "Users"
+USING GIST (
+  ST_SetSRID(
+    ST_MakePoint(
+      CAST("address"->'coordinates'->>'longitude' AS DOUBLE PRECISION),
+      CAST("address"->'coordinates'->>'latitude' AS DOUBLE PRECISION)
+    ),
+    4326
+  )
+);

--- a/server/src/database/migrations/init/tables.sql
+++ b/server/src/database/migrations/init/tables.sql
@@ -172,27 +172,3 @@ CREATE TABLE "EventMedia" (
 COMMENT ON TABLE "EventMedia" IS 'Junction table for many-to-many relationship between Events and Media';
 COMMENT ON COLUMN "EventMedia"."eventId" IS 'ID of the event';
 COMMENT ON COLUMN "EventMedia"."mediaId" IS 'ID of the media';
-
--- Spatial index on Events.location coordinates
-CREATE INDEX IF NOT EXISTS events_location_gix ON "Events"
-USING GIST (
-  ST_SetSRID(
-    ST_MakePoint(
-      CAST("location"->'coordinates'->>'longitude' AS DOUBLE PRECISION),
-      CAST("location"->'coordinates'->>'latitude' AS DOUBLE PRECISION)
-    ),
-    4326
-  )
-);
-
--- Spatial index on Users.address coordinates
-CREATE INDEX IF NOT EXISTS users_address_gix ON "Users"
-USING GIST (
-  ST_SetSRID(
-    ST_MakePoint(
-      CAST("address"->'coordinates'->>'longitude' AS DOUBLE PRECISION),
-      CAST("address"->'coordinates'->>'latitude' AS DOUBLE PRECISION)
-    ),
-    4326
-  )
-);

--- a/server/src/features/events/model.ts
+++ b/server/src/features/events/model.ts
@@ -13,6 +13,8 @@ import {
   IReaction,
 } from "@definitions/types";
 
+const sequelize = getDBConnection();
+
 // Create a type that makes timestamp fields optional for model attributes
 type EventAttributes = Omit<IEvent, "createdAt" | "updatedAt" | "deletedAt">;
 
@@ -103,9 +105,20 @@ Event.init(
   {
     modelName: "Event",
     tableName: EVENT_TABLE_NAME,
-    sequelize: getDBConnection(),
+    sequelize,
     timestamps: true,
     paranoid: true,
+    indexes: [
+      {
+        name: "events_location_gix",
+        using: "GIST",
+        fields: [
+          sequelize.literal(
+            `ST_SetSRID(ST_MakePoint(CAST("location"->'coordinates'->>'longitude' AS DOUBLE PRECISION), CAST("location"->'coordinates'->>'latitude' AS DOUBLE PRECISION)), 4326)`
+          ),
+        ],
+      },
+    ],
   }
 );
 

--- a/server/src/features/users/model.ts
+++ b/server/src/features/users/model.ts
@@ -3,6 +3,8 @@ import { DataTypes, Model } from "sequelize";
 import { getUUIDv7 } from "@helpers";
 import { USER_TABLE_NAME } from "./constants";
 import { IBaseUser } from "@/definitions/types";
+
+const sequelize = getDBConnection();
 type UserAttributes = Omit<
   IBaseUser,
   "createdAt" | "updatedAt" | "deletedAt" | "media" | "profilePic"
@@ -57,9 +59,20 @@ User.init(
   {
     modelName: "User",
     tableName: USER_TABLE_NAME,
-    sequelize: getDBConnection(),
+    sequelize,
     timestamps: true,
     paranoid: true,
+    indexes: [
+      {
+        name: "users_address_gix",
+        using: "GIST",
+        fields: [
+          sequelize.literal(
+            `ST_SetSRID(ST_MakePoint(CAST("address"->'coordinates'->>'longitude' AS DOUBLE PRECISION), CAST("address"->'coordinates'->>'latitude' AS DOUBLE PRECISION)), 4326)`
+          ),
+        ],
+      },
+    ],
   }
 );
 


### PR DESCRIPTION
## Summary
- enable `postgis` extension
- add GIST indexes for event and user coordinates

## Testing
- `npm run build` *(fails: Cannot find module due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_686505539df0832ba03b6f68d78b1d66