### PR TITLE
Remove db utils wrappers

### DIFF
--- a/server/src/features/tags/service.ts
+++ b/server/src/features/tags/service.ts
@@ -1,11 +1,5 @@
 import { IEvent, IPaginationParams, ITag } from "@/definitions/types";
-import {
-  createRecord,
-  deleteRecord,
-  findAllWithPagination,
-  findById,
-  updateRecord,
-} from "@utils/dbUtils";
+import { findAllWithPagination } from "@utils/dbUtils";
 import { validateTagCreate, validateTagUpdate } from "./validation";
 import { Tag } from "./model";
 import { Event } from "../events/model";
@@ -31,7 +25,8 @@ class TagService {
 
   @MethodCacheSync({})
   async getById(id: string) {
-    return findById(Tag, id);
+    const res = await Tag.findByPk(id, { raw: true });
+    return res as any;
   }
 
   async getAll(
@@ -43,7 +38,8 @@ class TagService {
   }
 
   async _getByIdNoCache(id: string) {
-    return findById(Tag, id);
+    const res = await Tag.findByPk(id, { raw: true });
+    return res as any;
   }
 
   async getRootTags() {
@@ -78,52 +74,59 @@ class TagService {
 
   @MethodCacheSync<ITag>()
   async create<U extends Partial<Omit<ITag, "id" | "updatedAt">>>(data: U) {
-    const res = await validateTagCreate(data, (validatedData: U) =>
-      createRecord(Tag, validatedData)
-    );
+    const res = await validateTagCreate(data, async (validatedData: U) => {
+      const row = await Tag.create(validatedData as any);
+      return row.toJSON() as any;
+    });
     return res;
   }
 
   @MethodCacheSync<ITag>()
   async update<U extends Partial<ITag>>(id: string, data: U) {
-    const res = await validateTagUpdate(data, (validatedData: U) =>
-      updateRecord(Tag, { id }, validatedData)
-    );
+    const res = await validateTagUpdate(data, async (validatedData: U) => {
+      const [count, rows] = await Tag.update(validatedData as any, {
+        where: { id },
+        returning: true,
+      });
+      if (count === 0) throw new Error("Tag not found");
+      return rows[0];
+    });
     return res;
   }
 
   @MethodCacheSync<ITag>()
   delete(id: string) {
-    return deleteRecord(Tag, { id });
+    return (async () => {
+      const row = await Tag.findByPk(id);
+      if (!row) return null;
+      await row.destroy();
+      return row.toJSON() as any;
+    })();
   }
 
   @MethodCacheSync<ITag>({})
   async associateTagToEvent(eventId: string, tagId: string) {
-    const event = await findById(Event, eventId);
+    const event = (await Event.findByPk(eventId, { raw: true })) as any;
     if (!event) return null;
     const tags = new Set((event.tags || []) as string[]);
     tags.add(tagId);
-    const data = await updateRecord(
-      Event,
-      { id: eventId },
-      { tags: Array.from(tags) }
+    const [, rows] = await Event.update(
+      { tags: Array.from(tags) } as any,
+      { where: { id: eventId }, returning: true }
     );
-    return data;
+    return rows[0];
   }
 
   async dissociateTagFromEvent(eventId: string, tagId: string) {
     await deleteEventTagsCache(eventId);
-    const event = await findById(Event, eventId);
+    const event = (await Event.findByPk(eventId, { raw: true })) as any;
     if (!event) return null;
     const tags = (event.tags || []) as string[];
-    const data = await updateRecord(
-      Event,
-      { id: eventId },
-      {
-        tags: tags.filter((t) => t !== tagId),
-      }
+    const [, rows] = await Event.update(
+      { tags: tags.filter((t) => t !== tagId) } as any,
+      { where: { id: eventId }, returning: true }
     );
-    return data;
+    return rows[0];
   }
 
   @MethodCacheSync<ITag>({


### PR DESCRIPTION
## Summary
- keep only pagination helper in db utils
- use Sequelize models directly in services

## Testing
- `npm run build` *(fails: Cannot fetch packages)*

------
https://chatgpt.com/codex/tasks/task_b_686a3c8c81ec832badf133150fb95f17