### PR TITLE
Add video processing worker and queue

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "build": "tsc --project tsconfig.json && tscpaths -p tsconfig.build.json -s ./ -o ./dist",
     "dev": "nodemon --watch src --ext ts --exec \"tsx -r tsconfig-paths/register\" src/index.ts",
-    "seed": "tsx -r tsconfig-paths/register src/misc/seeder.ts"
+    "seed": "tsx -r tsconfig-paths/register src/misc/seeder.ts",
+    "video-worker": "tsx -r tsconfig-paths/register src/workers/video.ts"
   },
   "dependencies": {
     "@supabase/postgrest-js": "^1.19.4",
@@ -35,6 +36,7 @@
     "ua-parser-js": "^2.0.3",
     "uuid": "^11.1.0",
     "cloudinary": "^2.7.0",
+    "bullmq": "^2.5.1",
     "winston": "^3.17.0",
     "winston-daily-rotate-file": "^5.0.0",
     "swagger-jsdoc": "^6.2.8",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,12 +2,14 @@ import createServer from "@app";
 import config from "@config";
 import logger from "@logger";
 import { initializeSocket } from "@socket";
+import { initializeMediaRealtime } from "@supabase/realtime";
 import http from "http";
 
 const app = createServer();
 
 const httpServer = http.createServer(app);
 initializeSocket(httpServer);
+initializeMediaRealtime();
 
 httpServer.listen(config.port, () => {
   logger.info(`Server is running on port ${config.port}`);

--- a/server/src/queues/video.ts
+++ b/server/src/queues/video.ts
@@ -1,0 +1,12 @@
+import { Queue } from 'bullmq';
+import redis from '@/connections/redis';
+
+export const VIDEO_QUEUE_NAME = 'video-processing';
+
+export const videoQueue = new Queue(VIDEO_QUEUE_NAME, {
+  connection: redis,
+});
+
+export const addVideoJob = async (mediaId: string) => {
+  await videoQueue.add('process', { mediaId });
+};

--- a/server/src/supabase/realtime.ts
+++ b/server/src/supabase/realtime.ts
@@ -1,0 +1,34 @@
+import supabase from './index';
+import { Event } from '@/features/events/model';
+import EventService from '@/features/events/service';
+import { Op } from 'sequelize';
+import { emitSocketEvent } from '@/socket/emitter';
+import { PLATFORM_SOCKET_EVENTS } from '@/constants';
+import logger from '@/logger';
+
+export function initializeMediaRealtime() {
+  const channel = supabase.channel('media-updates');
+  const eventService = new EventService();
+  channel
+    .on(
+      'postgres_changes',
+      { event: 'UPDATE', schema: 'public', table: 'Media' },
+      async (payload) => {
+        const mediaId = payload.new.id as string;
+        try {
+          const events = await Event.findAll({
+            where: { media: { [Op.contains]: [mediaId] } },
+            raw: true,
+          });
+          for (const e of events) {
+            const ev = await eventService.getEventData((e as any).id);
+            emitSocketEvent(PLATFORM_SOCKET_EVENTS.EVENT_UPDATED, { data: ev });
+          }
+        } catch (err) {
+          logger.error('Realtime handler error', err);
+        }
+      }
+    )
+    .subscribe()
+    .catch((e) => logger.error('Realtime subscribe error', e));
+}

--- a/server/src/workers/video.ts
+++ b/server/src/workers/video.ts
@@ -1,0 +1,100 @@
+import { Worker } from 'bullmq';
+import redis from '@/connections/redis';
+import { VIDEO_QUEUE_NAME } from '@/queues/video';
+import MediaService from '@/features/media/service';
+import EventService from '@/features/events/service';
+import { Event } from '@/features/events/model';
+import { Op } from 'sequelize';
+import { emitSocketEvent } from '@/socket/emitter';
+import { PLATFORM_SOCKET_EVENTS } from '@/constants';
+import logger from '@/logger';
+import { tmpdir } from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+import { spawn } from 'child_process';
+
+const mediaService = new MediaService();
+const eventService = new EventService();
+
+const runFFmpeg = (args: string[]) =>
+  new Promise<void>((resolve, reject) => {
+    const p = spawn('ffmpeg', args);
+    p.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`ffmpeg exited with code ${code}`));
+    });
+  });
+
+export default new Worker(
+  VIDEO_QUEUE_NAME,
+  async (job) => {
+    const { mediaId } = job.data as { mediaId: string };
+    try {
+      const media = await mediaService.getById(mediaId);
+      if (!media) return;
+
+      const { signedUrl } = await mediaService.getPublicUrl(
+        media.url,
+        media.storage.bucket,
+        media.storage.provider
+      );
+      const input = path.join(tmpdir(), `${mediaId}${path.extname(media.url)}`);
+      const res = await fetch(signedUrl);
+      await fs.writeFile(input, Buffer.from(await res.arrayBuffer()));
+
+      const out3x = path.join(tmpdir(), `${mediaId}@3x.gif`);
+      const out2x = path.join(tmpdir(), `${mediaId}@2x.gif`);
+      const out1x = path.join(tmpdir(), `${mediaId}@1x.gif`);
+
+      await runFFmpeg(['-y', '-i', input, '-vf', 'scale=480:-1', out3x]);
+      await runFFmpeg(['-y', '-i', out3x, '-vf', 'scale=320:-1', out2x]);
+      await runFFmpeg(['-y', '-i', out3x, '-vf', 'scale=160:-1', out1x]);
+
+      const upload = async (file: string, suffix: string) => {
+        const signed = await mediaService.getSignedUrlForPublicUpload({
+          path: `${mediaId}${suffix}.gif`,
+        });
+        await mediaService.uploadFileToSignedUrl({
+          bucket: signed.bucket ?? 'public',
+          path: signed.path,
+          base64FileData: (await fs.readFile(file)).toString('base64'),
+          mimeType: 'image/gif',
+          token: signed.token,
+        });
+        return signed.path;
+      };
+
+      const [t1, t2, t3] = await Promise.all([
+        upload(out1x, '@1x'),
+        upload(out2x, '@2x'),
+        upload(out3x, '@3x'),
+      ]);
+
+      await mediaService.update(mediaId, {
+        thumbnail: t2,
+        metadata: {
+          ...(media.metadata || {}),
+          thumbnails: { '@1x': t1, '@2x': t2, '@3x': t3 },
+        },
+      });
+
+      await fs.unlink(input).catch(() => {});
+      await fs.unlink(out1x).catch(() => {});
+      await fs.unlink(out2x).catch(() => {});
+      await fs.unlink(out3x).catch(() => {});
+
+      const events = await Event.findAll({
+        where: { media: { [Op.contains]: [mediaId] } },
+        raw: true,
+      });
+
+      for (const e of events) {
+        const event = await eventService.getEventData((e as any).id);
+        emitSocketEvent(PLATFORM_SOCKET_EVENTS.EVENT_UPDATED, { data: event });
+      }
+    } catch (err) {
+      logger.error('Video worker error', err);
+    }
+  },
+  { connection: redis }
+);


### PR DESCRIPTION
## Summary
- add bullmq queue for video processing
- create video worker using ffmpeg
- queue jobs when upload completes
- stream media table updates using Supabase realtime
- remove client-side video compression
- trigger server on upload completion

## Testing
- `npm run build` *(fails: Cannot find module 'cors' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_b_686a5a9c45c8832b99ee0a0eb3b9645d