### PR TITLE
Nest event resources under v1 routes

### DIFF
--- a/client/common/api/events.action.ts
+++ b/client/common/api/events.action.ts
@@ -7,7 +7,7 @@ export const getAllEvents = async (): Promise<{
   data: { items: IEvent[]; pagination: IPaginationParams };
   error: any;
 }> => {
-  const response = await axiosClient.get("/events");
+  const response = await axiosClient.get("/v1/events");
   return response.data;
 };
 
@@ -17,36 +17,36 @@ export const getEventById = async (
   data: IEvent;
   error: any;
 }> => {
-  const response = await axiosClient.get(`/events/${id}`);
+  const response = await axiosClient.get(`/v1/events/${id}`);
   return response.data;
 };
 
 export const getEventThreads = async (eventId: string, pagination?: Partial<IPaginationParams>) => {
   if (!eventId) return;
   const queryParams = new URLSearchParams(formTruthyValues(pagination || {}));
-  const threadsResponse = await axiosClient.get(`/events/${eventId}/threads?${queryParams.toString()}`);
+  const threadsResponse = await axiosClient.get(`/v1/events/${eventId}/threads?${queryParams.toString()}`);
   return threadsResponse.data;
 };
 
 export const createEvent = async (data: Record<string, any>): Promise<IBaseResponse<IEvent>> => {
-  const createResponse = await axiosClient.post("/events", data);
+  const createResponse = await axiosClient.post("/v1/events", data);
   return createResponse.data;
 };
 
 export const updateEvent = async (id: string, data: Record<string, any>): Promise<IBaseResponse<IEvent>> => {
-  const res = await axiosClient.put(`/events/${id}`, data);
+  const res = await axiosClient.put(`/v1/events/${id}`, data);
   return res.data;
 };
 
 export const cancelEvent = async (id: string): Promise<IBaseResponse<IEvent>> => {
-  const res = await axiosClient.put(`/events/${id}`, { status: EEventStatus.Cancelled });
+  const res = await axiosClient.put(`/v1/events/${id}`, { status: EEventStatus.Cancelled });
   return res.data;
 };
 
 export const getUserEvents = async (
   userId: string
 ): Promise<{ data: { items: IEvent[]; pagination: IPaginationParams }; error: any }> => {
-  const res = await axiosClient.get(`/events?createdBy=${userId}&status=draft,upcoming,ongoing,completed,cancelled`);
+  const res = await axiosClient.get(`/v1/events?createdBy=${userId}&status=draft,upcoming,ongoing,completed,cancelled`);
   return res.data;
 };
 
@@ -54,17 +54,17 @@ export const verifyEvent = async (
   eventId: string,
   currentCoordinates: { latitude: number; longitude: number }
 ): Promise<IBaseResponse<boolean>> => {
-  const res = await axiosClient.post(`/events/${eventId}/verify`, {
+  const res = await axiosClient.post(`/v1/events/${eventId}/verify`, {
     currentCoordinates
   });
   return res.data;
 };
 
 export const disassociateMediaFromEvent = async (eventId: string, mediaId: string): Promise<IBaseResponse<boolean>> => {
-  const res = await axiosClient.delete(`/events/${eventId}/media/${mediaId}`);
+  const res = await axiosClient.delete(`/v1/events/${eventId}/media/${mediaId}`);
   return res.data;
 };
 export const dissociateTagFromEvent = async (eventId: string, tagId: string): Promise<IBaseResponse<boolean>> => {
-  const res = await axiosClient.delete(`/events/${eventId}/tags/${tagId}`);
+  const res = await axiosClient.delete(`/v1/events/${eventId}/tags/${tagId}`);
   return res.data;
 };

--- a/server/src/routes/events.route.ts
+++ b/server/src/routes/events.route.ts
@@ -158,27 +158,6 @@ router.delete(
   asyncHandler(deleteEventTag)
 );
 
-/**
- * @openapi
- * /events/{eventId}/threads:
- *   get:
- *     tags: [Events]
- *     summary: Get threads for event
- *     parameters:
- *       - in: path
- *         name: eventId
- *         required: true
- *         schema:
- *           type: string
- *     responses:
- *       200:
- *         description: List of threads
- */
-router.get(
-  "/:eventId/threads",
-  [validateParams(["eventId"])],
-  asyncHandler(getEventThreads)
-);
 
 /**
  * @openapi

--- a/server/src/routes/v1/events.route.ts
+++ b/server/src/routes/v1/events.route.ts
@@ -1,0 +1,253 @@
+import { Router } from "express";
+import {
+  asyncHandler,
+  sessionParser,
+  userParser,
+  validateParams,
+  paginationParser,
+} from "@middlewares";
+import {
+  createEvent,
+  deleteEvent,
+  deleteEventMedia,
+  deleteEventTag,
+  eventJoinLeaveHandler,
+  getEventById,
+  getEventThreads,
+  getEvents,
+  updateEvent,
+  verifyEvent,
+} from "@features/events/controller";
+import {
+  createThread,
+  deleteThread,
+  getThread,
+  updateThread,
+} from "@features/threads/controller";
+import {
+  createMessage,
+  deleteMessage,
+  getChildMessages,
+  getMessageById,
+  getMessages,
+  updateMessage,
+} from "@features/messages/controller";
+import ReactionService from "@features/reactions/service";
+import { ICustomRequest } from "@definitions/types";
+import { NotFoundError } from "@exceptions";
+
+const router = Router({ mergeParams: true });
+const reactionService = new ReactionService();
+
+router.use([sessionParser, userParser]);
+
+router.route("/")
+  .get(asyncHandler(getEvents))
+  .post(asyncHandler(createEvent));
+
+router.route("/:eventId")
+  .get([validateParams(["eventId"])], asyncHandler(getEventById))
+  .put([validateParams(["eventId"])], asyncHandler(updateEvent))
+  .delete([validateParams(["eventId"])], asyncHandler(deleteEvent));
+
+router.delete(
+  "/:eventId/tags/:tagId",
+  [validateParams(["eventId", "tagId"])],
+  asyncHandler(deleteEventTag)
+);
+
+router.post(
+  "/:eventId/verify",
+  [validateParams(["eventId"])],
+  asyncHandler(verifyEvent)
+);
+
+router.get(
+  "/:eventId/:action",
+  [validateParams(["eventId", "action"])],
+  asyncHandler(eventJoinLeaveHandler)
+);
+
+router.delete(
+  "/:eventId/media/:mediaId",
+  [validateParams(["eventId", "mediaId"])],
+  asyncHandler(deleteEventMedia)
+);
+
+// Threads
+router.route("/:eventId/threads")
+  .get(
+    [validateParams(["eventId"]), paginationParser],
+    asyncHandler(getEventThreads)
+  )
+  .post(
+    [validateParams(["eventId"])],
+    asyncHandler((req, res, next) => {
+      req.body.eventId = req.params.eventId;
+      return createThread(req, res, next);
+    })
+  );
+
+router.route("/:eventId/threads/:threadId")
+  .get([validateParams(["eventId", "threadId"])], asyncHandler(getThread))
+  .put([validateParams(["eventId", "threadId"])], asyncHandler(updateThread))
+  .delete([validateParams(["eventId", "threadId"])], asyncHandler(deleteThread));
+
+router
+  .route("/:eventId/threads/:threadId/messages")
+  .get(
+    [validateParams(["eventId", "threadId"]), paginationParser],
+    asyncHandler(getMessages)
+  )
+  .post(
+    [validateParams(["eventId", "threadId"])],
+    asyncHandler((req, res, next) => {
+      req.body.threadId = req.params.threadId;
+      return createMessage(req, res, next);
+    })
+  );
+
+router.route("/:eventId/threads/:threadId/messages/:messageId")
+  .get(
+    [validateParams(["eventId", "threadId", "messageId"])],
+    asyncHandler(getMessageById)
+  )
+  .put(
+    [validateParams(["eventId", "threadId", "messageId"])],
+    asyncHandler(updateMessage)
+  )
+  .delete(
+    [validateParams(["eventId", "threadId", "messageId"])],
+    asyncHandler(deleteMessage)
+  );
+
+router.get(
+  "/:eventId/threads/:threadId/child-messages/:parentId",
+  [validateParams(["eventId", "threadId", "parentId"]), paginationParser],
+  asyncHandler(getChildMessages)
+);
+
+// Reactions for events
+router.get(
+  "/:eventId/reactions",
+  [validateParams(["eventId"])],
+  asyncHandler(async (req: ICustomRequest, res) => {
+    const reactions = await reactionService.getReactions(`events/${req.params.eventId}`, req.query.userId as string | undefined);
+    res.status(200).json({ data: reactions, error: null });
+  })
+);
+
+router.post(
+  "/:eventId/reactions",
+  [validateParams(["eventId"])],
+  asyncHandler(async (req: ICustomRequest, res) => {
+    const reaction = await reactionService.create({
+      contentId: `events/${req.params.eventId}`,
+      emoji: req.body.emoji,
+      userId: req.user.id,
+    });
+    res.status(201).json({ data: reaction, error: null });
+  })
+);
+
+router
+  .route("/:eventId/reactions/:reactionId")
+  .put(
+    [validateParams(["eventId", "reactionId"])],
+    asyncHandler(async (req: ICustomRequest, res) => {
+      const updated = await reactionService.update(req.params.reactionId, req.body);
+      res.status(200).json({ data: updated, error: null });
+    })
+  )
+  .delete(
+    [validateParams(["eventId", "reactionId"])],
+    asyncHandler(async (req: ICustomRequest, res) => {
+      const deleted = await reactionService.delete(req.params.reactionId);
+      if (!deleted) throw new NotFoundError("Reaction not found");
+      res.status(200).json({ data: deleted, error: null });
+    })
+  );
+
+// Reactions for threads
+router.get(
+  "/:eventId/threads/:threadId/reactions",
+  [validateParams(["eventId", "threadId"])],
+  asyncHandler(async (req: ICustomRequest, res) => {
+    const reactions = await reactionService.getReactions(`threads/${req.params.threadId}`, req.query.userId as string | undefined);
+    res.status(200).json({ data: reactions, error: null });
+  })
+);
+
+router.post(
+  "/:eventId/threads/:threadId/reactions",
+  [validateParams(["eventId", "threadId"])],
+  asyncHandler(async (req: ICustomRequest, res) => {
+    const reaction = await reactionService.create({
+      contentId: `threads/${req.params.threadId}`,
+      emoji: req.body.emoji,
+      userId: req.user.id,
+    });
+    res.status(201).json({ data: reaction, error: null });
+  })
+);
+
+router
+  .route("/:eventId/threads/:threadId/reactions/:reactionId")
+  .put(
+    [validateParams(["eventId", "threadId", "reactionId"])],
+    asyncHandler(async (req: ICustomRequest, res) => {
+      const updated = await reactionService.update(req.params.reactionId, req.body);
+      res.status(200).json({ data: updated, error: null });
+    })
+  )
+  .delete(
+    [validateParams(["eventId", "threadId", "reactionId"])],
+    asyncHandler(async (req: ICustomRequest, res) => {
+      const deleted = await reactionService.delete(req.params.reactionId);
+      if (!deleted) throw new NotFoundError("Reaction not found");
+      res.status(200).json({ data: deleted, error: null });
+    })
+  );
+
+// Reactions for messages
+router.get(
+  "/:eventId/threads/:threadId/messages/:messageId/reactions",
+  [validateParams(["eventId", "threadId", "messageId"])],
+  asyncHandler(async (req: ICustomRequest, res) => {
+    const reactions = await reactionService.getReactions(`messages/${req.params.messageId}`, req.query.userId as string | undefined);
+    res.status(200).json({ data: reactions, error: null });
+  })
+);
+
+router.post(
+  "/:eventId/threads/:threadId/messages/:messageId/reactions",
+  [validateParams(["eventId", "threadId", "messageId"])],
+  asyncHandler(async (req: ICustomRequest, res) => {
+    const reaction = await reactionService.create({
+      contentId: `messages/${req.params.messageId}`,
+      emoji: req.body.emoji,
+      userId: req.user.id,
+    });
+    res.status(201).json({ data: reaction, error: null });
+  })
+);
+
+router
+  .route("/:eventId/threads/:threadId/messages/:messageId/reactions/:reactionId")
+  .put(
+    [validateParams(["eventId", "threadId", "messageId", "reactionId"])],
+    asyncHandler(async (req: ICustomRequest, res) => {
+      const updated = await reactionService.update(req.params.reactionId, req.body);
+      res.status(200).json({ data: updated, error: null });
+    })
+  )
+  .delete(
+    [validateParams(["eventId", "threadId", "messageId", "reactionId"])],
+    asyncHandler(async (req: ICustomRequest, res) => {
+      const deleted = await reactionService.delete(req.params.reactionId);
+      if (!deleted) throw new NotFoundError("Reaction not found");
+      res.status(200).json({ data: deleted, error: null });
+    })
+  );
+
+export default router;

--- a/server/src/routes/v1/index.ts
+++ b/server/src/routes/v1/index.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import eventsRouter from "./events.route";
+
+const router = Router();
+
+router.use("/events", eventsRouter);
+
+export default router;


### PR DESCRIPTION
## Summary
- keep existing routes untouched but remove thread lookup from `events.route.ts`
- add `v1` router and expose all event related resources under `/v1/events`
- update frontend event API calls to new `/v1/events` endpoints

## Testing
- `pnpm -r build` *(fails: Cannot find module 'npm:@supabase/supabase-js' etc.)*

------
https://chatgpt.com/codex/tasks/task_b_6874a4fe63ac832ba51b357f7a1070c1