### PR TITLE
Implement chat thread locking and view-only mode

### DIFF
--- a/client/common/api/threads.action.ts
+++ b/client/common/api/threads.action.ts
@@ -11,3 +11,33 @@ export const getThreadById = async ({ id, includeMessages = false }: GetThreadBy
   const threadResponse = await axiosClient.get(`/threads/${id}?includeMessage=${includeMessages}`);
   return threadResponse.data;
 };
+
+/**
+ * Lock a thread (author only)
+ * @param threadId - The ID of the thread to lock
+ * @returns Promise with the locked thread data
+ */
+export const lockThread = async (threadId: string): Promise<any> => {
+  try {
+    const response = await axiosClient.post(`/threads/${threadId}/lock`);
+    return response.data;
+  } catch (error) {
+    console.error("Error locking thread:", error);
+    throw error;
+  }
+};
+
+/**
+ * Unlock a thread (author only)
+ * @param threadId - The ID of the thread to unlock
+ * @returns Promise with the unlocked thread data
+ */
+export const unlockThread = async (threadId: string): Promise<any> => {
+  try {
+    const response = await axiosClient.post(`/threads/${threadId}/unlock`);
+    return response.data;
+  } catch (error) {
+    console.error("Error unlocking thread:", error);
+    throw error;
+  }
+};

--- a/client/components/MessageInputBar/index.tsx
+++ b/client/components/MessageInputBar/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { CardWrapper } from "../ui/common-styles";
 import { XStack, ScrollView, View, YStack, Text } from "tamagui";
-import { Plus, RotateCw, SendHorizontal, X } from "@tamagui/lucide-icons";
+import { Plus, RotateCw, SendHorizontal, X, Lock } from "@tamagui/lucide-icons";
 import { FilledButton, OutlineButton } from "../ui/Buttons";
 import { TextareaField } from "../Form";
 import { Platform } from "react-native";
@@ -14,19 +14,25 @@ import CustomTooltip from "../CustomTooltip";
 import { EMediaType } from "@/definitions/enums";
 import { IAttachedFile } from "@/common/utils/file.utils";
 import { Badge } from "../ui/Badge";
+import { IBaseThread } from "@/definitions/types";
+import { isThreadLocked } from "@/utils/thread.utils";
 
 interface IProps {
   context: Record<string, any>;
   sendButtonCb: (data: Record<string, any>, onSuccess?: () => void) => void;
+  thread?: IBaseThread; // Add thread prop to check lock status
 }
 
-const MessageInputBar = ({ context, sendButtonCb }: IProps) => {
+const MessageInputBar = ({ context, sendButtonCb, thread }: IProps) => {
   const [message, setMessage] = useState("");
   const [attachedFiles, setAttachedFiles] = useState<IAttachedFile[]>([]);
   const textAreaRef = useRef<any>(null);
 
   const maxAttachmentLimit = context?.maxAttachments;
   const [height, setHeight] = useState(40);
+
+  // Check if thread is locked
+  const threadLocked = thread ? isThreadLocked(thread) : false;
 
   const handleMessageChange = (text: string) => {
     setMessage(text);
@@ -175,6 +181,25 @@ const MessageInputBar = ({ context, sendButtonCb }: IProps) => {
 
   const hasValidFiles = attachedFiles.some((file) => !file.error);
   const isAddButtonDisabled = !!maxAttachmentLimit ? maxAttachmentLimit <= attachedFiles.length : false;
+
+  // If thread is locked, show a disabled state
+  if (threadLocked) {
+    return (
+      <CardWrapper
+        p={"$3"}
+        rounded={"$3"}
+        opacity={0.6}
+        backgroundColor="$color2"
+      >
+        <XStack gap="$3" alignItems="center" justifyContent="center">
+          <Lock size={16} color="$color8" />
+          <Text fontSize="$3" color="$color8" textAlign="center">
+            This thread is locked. No new messages can be added.
+          </Text>
+        </XStack>
+      </CardWrapper>
+    );
+  }
 
   return (
     <CardWrapper

--- a/client/components/ThreadLockIndicator.tsx
+++ b/client/components/ThreadLockIndicator.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { XStack, YStack, Text, View } from "tamagui";
+import { Lock, Unlock } from "@tamagui/lucide-icons";
+import { Badge } from "./ui/Badge";
+import { IBaseThread } from "@/definitions/types";
+import { isThreadLocked, getThreadLockStatusMessage, canUserLockThread } from "@/utils/thread.utils";
+import { useAuth } from "@/contexts/AuthContext";
+import { OutlineButton } from "./ui/Buttons";
+import { lockThread, unlockThread } from "@/common/api/threads.action";
+import { useToastController } from "@tamagui/toast";
+
+interface ThreadLockIndicatorProps {
+  thread: IBaseThread;
+  onLockStatusChange?: (isLocked: boolean) => void;
+  showControls?: boolean;
+}
+
+const ThreadLockIndicator: React.FC<ThreadLockIndicatorProps> = ({ 
+  thread, 
+  onLockStatusChange,
+  showControls = true 
+}) => {
+  const { user } = useAuth();
+  const toastController = useToastController();
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  const locked = isThreadLocked(thread);
+  const canControl = user && canUserLockThread(thread, user.id);
+  const lockMessage = getThreadLockStatusMessage(thread, user?.id);
+
+  const handleLockToggle = async () => {
+    if (!user || !canControl) return;
+
+    setIsLoading(true);
+    try {
+      if (locked) {
+        await unlockThread(thread.id);
+        toastController.show("Thread unlocked successfully", {
+          message: "Users can now add messages and reactions",
+        });
+      } else {
+        await lockThread(thread.id);
+        toastController.show("Thread locked successfully", {
+          message: "No new messages or reactions can be added",
+        });
+      }
+      onLockStatusChange?.(!locked);
+    } catch (error: any) {
+      toastController.show("Error", {
+        message: error?.response?.data?.error || error?.message || "Something went wrong",
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!locked && !canControl) {
+    return null; // Don't show anything if thread is not locked and user can't control it
+  }
+
+  return (
+    <XStack gap="$3" alignItems="center" paddingVertical="$2">
+      {/* Lock Status Badge */}
+      <Badge variant={locked ? "danger" : "success"}>
+        <XStack gap="$2" alignItems="center">
+          {locked ? <Lock size={14} /> : <Unlock size={14} />}
+          <Text fontSize="$2" fontWeight="600">
+            {locked ? "Locked" : "Unlocked"}
+          </Text>
+        </XStack>
+      </Badge>
+
+      {/* Lock Message */}
+      {lockMessage && (
+        <Text fontSize="$2" color="$color10">
+          {lockMessage}
+        </Text>
+      )}
+
+      {/* Controls for thread author */}
+      {showControls && canControl && (
+        <OutlineButton
+          size="$2"
+          onPress={handleLockToggle}
+          disabled={isLoading}
+          variant={locked ? "success" : "danger"}
+        >
+          <XStack gap="$2" alignItems="center">
+            {locked ? <Unlock size={14} /> : <Lock size={14} />}
+            <Text fontSize="$2">
+              {isLoading ? "Processing..." : locked ? "Unlock" : "Lock"}
+            </Text>
+          </XStack>
+        </OutlineButton>
+      )}
+    </XStack>
+  );
+};
+
+export default ThreadLockIndicator;

--- a/client/constants/global.ts
+++ b/client/constants/global.ts
@@ -18,6 +18,8 @@ export const PLATFORM_SOCKET_EVENTS = {
   THREAD_CREATED: "thread:created",
   THREAD_UPDATED: "thread:updated",
   THREAD_DELETED: "thread:deleted",
+  THREAD_LOCKED: "thread:locked",
+  THREAD_UNLOCKED: "thread:unlocked",
 
   // MESSAGEs
   MESSAGE_CREATED: "message:created",

--- a/client/definitions/types/index.ts
+++ b/client/definitions/types/index.ts
@@ -68,7 +68,7 @@ export interface IPaginatedDataResponse<T> {
 }
 
 // Thread Lock History
-interface ILockHistory {
+export interface ILockHistory {
   lockedBy: string; // ID of the user who locked the thread
   lockedAt: Date; // Timestamp of when the thread was locked
 }

--- a/client/screens/EventDetails/MessageViewSheetContent.tsx
+++ b/client/screens/EventDetails/MessageViewSheetContent.tsx
@@ -7,6 +7,9 @@ import { PLATFORM_SOCKET_EVENTS } from "@/constants/global";
 import { useToastController } from "@tamagui/toast";
 import { useLocalSearchParams } from "expo-router";
 import { useSocket } from "@/contexts/Socket";
+import { getThreadById } from "@/common/api/threads.action";
+import { IBaseThread } from "@/definitions/types";
+import ThreadLockIndicator from "@/components/ThreadLockIndicator";
 
 interface Props {
   setIsSheetOpen: Dispatch<SetStateAction<boolean>>;
@@ -22,6 +25,50 @@ const MessageViewSheetContent = ({ handleClick, handleSheetBack, sheetStack }: P
   const { user: currentAuthenticatedUser } = useAuth();
   const toastController = useToastController();
   const socket = useSocket();
+  const [threadData, setThreadData] = useState<IBaseThread | null>(null);
+
+  // Get the current thread ID from the top sheet
+  const currentThreadId = sheetStack[sheetStack.length - 1]?.threadId;
+
+  // Fetch thread data when threadId changes
+  useEffect(() => {
+    if (currentThreadId) {
+      getThreadById({ id: currentThreadId })
+        .then((response) => {
+          setThreadData(response.data);
+        })
+        .catch((error) => {
+          console.error("Error fetching thread:", error);
+        });
+    } else {
+      setThreadData(null);
+    }
+  }, [currentThreadId]);
+
+  // Handle thread lock/unlock events
+  useEffect(() => {
+    if (!socket || !currentThreadId) return;
+
+    const handleThreadLocked = ({ data }: { data: { id: string; lockHistory: any[] } }) => {
+      if (data.id === currentThreadId) {
+        setThreadData((prev) => prev ? { ...prev, lockHistory: data.lockHistory } : null);
+      }
+    };
+
+    const handleThreadUnlocked = ({ data }: { data: { id: string; lockHistory: any[] } }) => {
+      if (data.id === currentThreadId) {
+        setThreadData((prev) => prev ? { ...prev, lockHistory: data.lockHistory } : null);
+      }
+    };
+
+    socket.on(PLATFORM_SOCKET_EVENTS.THREAD_LOCKED, handleThreadLocked);
+    socket.on(PLATFORM_SOCKET_EVENTS.THREAD_UNLOCKED, handleThreadUnlocked);
+
+    return () => {
+      socket.off(PLATFORM_SOCKET_EVENTS.THREAD_LOCKED, handleThreadLocked);
+      socket.off(PLATFORM_SOCKET_EVENTS.THREAD_UNLOCKED, handleThreadUnlocked);
+    };
+  }, [socket, currentThreadId]);
 
   return (
     <>
@@ -46,8 +93,28 @@ const MessageViewSheetContent = ({ handleClick, handleSheetBack, sheetStack }: P
         ))}
       </View>
 
+      {/* Show thread lock indicator if thread exists */}
+      {threadData && (
+        <ThreadLockIndicator 
+          thread={threadData} 
+          onLockStatusChange={(isLocked) => {
+            // Update local thread data when lock status changes
+            setThreadData((prev) => 
+              prev ? { 
+                ...prev, 
+                lockHistory: isLocked ? [...(prev.lockHistory || []), { 
+                  lockedBy: currentAuthenticatedUser?.id || '', 
+                  lockedAt: new Date() 
+                }] : []
+              } : null
+            );
+          }}
+        />
+      )}
+
       <MessageInputBar
         context={{ eventId: id, maxAttachments: 3 }}
+        thread={threadData}
         sendButtonCb={(data, onSuccess) => {
           // take the top most sheet data and based on that add message
           const topMostSheetData = sheetStack[sheetStack.length - 1];

--- a/client/utils/thread.utils.ts
+++ b/client/utils/thread.utils.ts
@@ -1,0 +1,67 @@
+import { IBaseThread, ILockHistory } from "@/definitions/types";
+
+/**
+ * Check if a thread is currently locked
+ * @param thread - The thread object to check
+ * @returns boolean - true if the thread is locked, false otherwise
+ */
+export const isThreadLocked = (thread: IBaseThread): boolean => {
+  if (!thread.lockHistory || thread.lockHistory.length === 0) {
+    return false;
+  }
+  
+  // Get the latest lock entry (assuming the array is chronologically ordered)
+  const latestLock = thread.lockHistory[thread.lockHistory.length - 1];
+  
+  // If there's a lock entry, the thread is locked
+  return !!latestLock.lockedBy && !!latestLock.lockedAt;
+};
+
+/**
+ * Get the current lock information for a thread
+ * @param thread - The thread object to check
+ * @returns ILockHistory | null - the lock info if locked, null if not locked
+ */
+export const getThreadLockInfo = (thread: IBaseThread): ILockHistory | null => {
+  if (!isThreadLocked(thread)) {
+    return null;
+  }
+  
+  return thread.lockHistory[thread.lockHistory.length - 1];
+};
+
+/**
+ * Check if a user can lock/unlock a thread (only thread author)
+ * @param thread - The thread object
+ * @param userId - The user ID to check permissions for
+ * @returns boolean - true if the user can lock/unlock the thread, false otherwise
+ */
+export const canUserLockThread = (thread: IBaseThread, userId: string): boolean => {
+  return thread.createdBy === userId;
+};
+
+/**
+ * Get a human-readable lock status message
+ * @param thread - The thread object
+ * @param currentUserId - The current user's ID
+ * @returns string - A message describing the lock status
+ */
+export const getThreadLockStatusMessage = (thread: IBaseThread, currentUserId?: string): string => {
+  if (!isThreadLocked(thread)) {
+    return "";
+  }
+  
+  const lockInfo = getThreadLockInfo(thread);
+  if (!lockInfo) {
+    return "";
+  }
+  
+  const isCurrentUser = currentUserId === lockInfo.lockedBy;
+  const lockDate = new Date(lockInfo.lockedAt).toLocaleDateString();
+  
+  if (isCurrentUser) {
+    return `You locked this thread on ${lockDate}`;
+  } else {
+    return `This thread was locked on ${lockDate}`;
+  }
+};

--- a/server/src/constants/index.ts
+++ b/server/src/constants/index.ts
@@ -62,6 +62,8 @@ export const PLATFORM_SOCKET_EVENTS = {
   THREAD_CREATED: "thread:created",
   THREAD_UPDATED: "thread:updated",
   THREAD_DELETED: "thread:deleted",
+  THREAD_LOCKED: "thread:locked",
+  THREAD_UNLOCKED: "thread:unlocked",
 
   // MESSAGEs
   MESSAGE_CREATED: "message:created",

--- a/server/src/features/messages/controller.ts
+++ b/server/src/features/messages/controller.ts
@@ -2,11 +2,13 @@ import { Response } from "express";
 import MessageService from "./service";
 import { ICustomRequest, IRequestPagination } from "@definitions/types";
 import { cleanQueryObject, isEmpty, pick } from "@utils";
-import { NotFoundError } from "@exceptions";
+import { NotFoundError, ForbiddenError } from "@exceptions";
 import { emitSocketEvent } from "@socket/emitter";
 import { PLATFORM_SOCKET_EVENTS } from "@constants";
+import ThreadsService from "@features/threads/service";
 
 const messagesService = new MessageService();
+const threadsService = new ThreadsService();
 
 export const getMessages = async (
   req: ICustomRequest & IRequestPagination,
@@ -29,6 +31,13 @@ export const getMessages = async (
 
 export const createMessage = async (req: ICustomRequest, res: Response) => {
   const { threadId } = req.params;
+  
+  // Check if the thread (or its parent chain) is locked before creating a message
+  const lockStatus = await threadsService.isThreadChainLocked(threadId);
+  if (lockStatus.isLocked) {
+    throw new ForbiddenError("Cannot add messages to a locked thread or its children");
+  }
+
   const message = await messagesService.create(
     pick({ ...req.body, threadId, isEdited: true }, [
       "userId",
@@ -51,6 +60,16 @@ export const createMessage = async (req: ICustomRequest, res: Response) => {
 
 export const updateMessage = async (req: ICustomRequest, res: Response) => {
   const { messageId } = req.params;
+  
+  // Get the message to check its thread
+  const existingMessage = await messagesService.getById(messageId);
+  if (existingMessage && existingMessage.threadId) {
+    const lockStatus = await threadsService.isThreadChainLocked(existingMessage.threadId);
+    if (lockStatus.isLocked) {
+      throw new ForbiddenError("Cannot edit messages in a locked thread or its children");
+    }
+  }
+
   const message = await messagesService.update(
     messageId,
     pick({ ...req.body, isEdited: true }, ["content", "isEdited"]),
@@ -68,6 +87,16 @@ export const updateMessage = async (req: ICustomRequest, res: Response) => {
 
 export const deleteMessage = async (req: ICustomRequest, res: Response) => {
   const { messageId } = req.params;
+  
+  // Get the message to check its thread
+  const existingMessage = await messagesService.getById(messageId);
+  if (existingMessage && existingMessage.threadId) {
+    const lockStatus = await threadsService.isThreadChainLocked(existingMessage.threadId);
+    if (lockStatus.isLocked) {
+      throw new ForbiddenError("Cannot delete messages in a locked thread or its children");
+    }
+  }
+
   const message = await messagesService.delete(messageId);
   emitSocketEvent(PLATFORM_SOCKET_EVENTS.MESSAGE_DELETED, {
     data: { id: messageId },

--- a/server/src/features/messages/service.ts
+++ b/server/src/features/messages/service.ts
@@ -9,8 +9,9 @@ import { Message } from "./model";
 import MediaService from "@features/media/service";
 import { isEmpty } from "@utils";
 import UserService from "@features/users/service";
-import { BadRequestError } from "@exceptions";
+import { BadRequestError, ForbiddenError } from "@exceptions";
 import ReactionService from "@features/reactions/service";
+import ThreadsService from "@features/threads/service";
 
 // Note: Thread data is intentionally not populated here to avoid
 // circular dependencies between services. Controllers should fetch
@@ -19,6 +20,7 @@ class MessageService {
   private readonly mediaService: MediaService;
   private readonly userService: UserService;
   private readonly reactionService: ReactionService;
+  private readonly threadsService: ThreadsService;
 
   private readonly populateFields = ["user", "reactions", "media"];
 
@@ -26,6 +28,7 @@ class MessageService {
     this.mediaService = new MediaService();
     this.userService = new UserService();
     this.reactionService = new ReactionService();
+    this.threadsService = new ThreadsService();
   }
 
   private async populateMessage(message: IMessage, fields: string[]) {
@@ -180,6 +183,14 @@ class MessageService {
     data: U,
     populate?: boolean | string[]
   ) {
+    // Check if the thread (or its parent chain) is locked before creating a message
+    if (data.threadId) {
+      const lockStatus = await this.threadsService.isThreadChainLocked(data.threadId);
+      if (lockStatus.isLocked) {
+        throw new ForbiddenError("Cannot add messages to a locked thread or its children");
+      }
+    }
+
     const created = await validateMessageCreate(data, async (validData) => {
       if (validData.parentId) {
         const parent = await this.getById(validData.parentId);
@@ -207,6 +218,15 @@ class MessageService {
     data: U,
     populate?: boolean | string[]
   ) {
+    // Get the message to check its thread
+    const existingMessage = await this.getById(id);
+    if (existingMessage && existingMessage.threadId) {
+      const lockStatus = await this.threadsService.isThreadChainLocked(existingMessage.threadId);
+      if (lockStatus.isLocked) {
+        throw new ForbiddenError("Cannot edit messages in a locked thread or its children");
+      }
+    }
+
     const updated = await validateMessageUpdate(data, async (validData) => {
       if (validData.parentId) {
         const parent = await this.getById(validData.parentId);

--- a/server/src/features/threads/controller.ts
+++ b/server/src/features/threads/controller.ts
@@ -80,3 +80,45 @@ export const deleteThread = async (req: ICustomRequest, res: Response) => {
   });
   return res.status(200).json(thread);
 };
+
+export const lockThread = async (req: ICustomRequest, res: Response) => {
+  const { threadId } = req.params;
+  const userId = req.user.id;
+  
+  const thread = await threadsService.lockThread(threadId, userId);
+  
+  emitSocketEvent(PLATFORM_SOCKET_EVENTS.THREAD_LOCKED, {
+    data: { 
+      id: threadId, 
+      lockHistory: thread.lockHistory,
+      lockedBy: userId 
+    },
+    error: null,
+  });
+  
+  return res.status(200).json({
+    data: thread,
+    error: null,
+  });
+};
+
+export const unlockThread = async (req: ICustomRequest, res: Response) => {
+  const { threadId } = req.params;
+  const userId = req.user.id;
+  
+  const thread = await threadsService.unlockThread(threadId, userId);
+  
+  emitSocketEvent(PLATFORM_SOCKET_EVENTS.THREAD_UNLOCKED, {
+    data: { 
+      id: threadId, 
+      lockHistory: thread.lockHistory,
+      unlockedBy: userId 
+    },
+    error: null,
+  });
+  
+  return res.status(200).json({
+    data: thread,
+    error: null,
+  });
+};

--- a/server/src/features/threads/helpers.ts
+++ b/server/src/features/threads/helpers.ts
@@ -18,3 +18,85 @@ export const setThreadCache = async (id: string, data: IBaseThread) => {
 export const deleteThreadCache = async (id: string) => {
   return await threadsCache.deleteItem(id);
 };
+
+/**
+ * Check if a thread is currently locked
+ * @param thread - The thread object to check
+ * @returns boolean - true if the thread is locked, false otherwise
+ */
+export const isThreadLocked = (thread: IBaseThread): boolean => {
+  if (!thread.lockHistory || thread.lockHistory.length === 0) {
+    return false;
+  }
+  
+  // Get the latest lock entry (assuming the array is chronologically ordered)
+  const latestLock = thread.lockHistory[thread.lockHistory.length - 1];
+  
+  // If there's a lock entry, the thread is locked
+  return !!latestLock.lockedBy && !!latestLock.lockedAt;
+};
+
+/**
+ * Get the current lock information for a thread
+ * @param thread - The thread object to check
+ * @returns ILockHistory | null - the lock info if locked, null if not locked
+ */
+export const getThreadLockInfo = (thread: IBaseThread): ILockHistory | null => {
+  if (!isThreadLocked(thread)) {
+    return null;
+  }
+  
+  return thread.lockHistory[thread.lockHistory.length - 1];
+};
+
+/**
+ * Check if a user can modify a locked thread (only the locker or creator can unlock)
+ * @param thread - The thread object
+ * @param userId - The user ID to check permissions for
+ * @returns boolean - true if the user can modify the thread, false otherwise
+ */
+export const canUserModifyLockedThread = (thread: IBaseThread, userId: string): boolean => {
+  if (!isThreadLocked(thread)) {
+    return true; // Not locked, anyone can modify
+  }
+  
+  const lockInfo = getThreadLockInfo(thread);
+  if (!lockInfo) {
+    return true;
+  }
+  
+  // User can modify if they are the locker or the thread creator
+  return lockInfo.lockedBy === userId || thread.createdBy === userId;
+};
+
+/**
+ * Lock a thread
+ * @param thread - The thread object to lock
+ * @param userId - The user ID who is locking the thread
+ * @returns IBaseThread - the updated thread object
+ */
+export const lockThread = (thread: IBaseThread, userId: string): IBaseThread => {
+  const lockEntry: ILockHistory = {
+    lockedBy: userId,
+    lockedAt: new Date(),
+  };
+  
+  const updatedThread = {
+    ...thread,
+    lockHistory: [...(thread.lockHistory || []), lockEntry],
+  };
+  
+  return updatedThread;
+};
+
+/**
+ * Unlock a thread
+ * @param thread - The thread object to unlock
+ * @returns IBaseThread - the updated thread object
+ */
+export const unlockThread = (thread: IBaseThread): IBaseThread => {
+  return {
+    ...thread,
+    lockHistory: [], // Clear lock history to unlock
+  };
+};

--- a/server/src/features/threads/service.ts
+++ b/server/src/features/threads/service.ts
@@ -151,8 +151,10 @@ class ThreadsService {
       throw new BadRequestError("Thread is already locked");
     }
 
-    // For now, allow anyone to lock. You might want to add permission checks here
-    // e.g., only moderators, thread creators, or event organizers can lock threads
+    // Only allow thread author to lock the thread
+    if (thread.createdBy !== userId) {
+      throw new ForbiddenError("Only the thread author can lock this thread");
+    }
 
     const lockedThread = lockThread(thread, userId);
     
@@ -177,9 +179,9 @@ class ThreadsService {
       throw new BadRequestError("Thread is not locked");
     }
 
-    // Check if user has permission to unlock
-    if (!canUserModifyLockedThread(thread, userId)) {
-      throw new ForbiddenError("You don't have permission to unlock this thread");
+    // Only allow thread author to unlock the thread
+    if (thread.createdBy !== userId) {
+      throw new ForbiddenError("Only the thread author can unlock this thread");
     }
 
     const unlockedThread = unlockThread(thread);

--- a/server/src/routes/threads.route.ts
+++ b/server/src/routes/threads.route.ts
@@ -41,6 +41,8 @@ import {
   getThread,
   getThreads,
   updateThread,
+  lockThread,
+  unlockThread,
 } from "@features/threads/controller";
 
 const router = Router();
@@ -77,6 +79,24 @@ router
   .get(asyncHandler(getThread))
   .put(asyncHandler(updateThread))
   .delete(asyncHandler(deleteThread));
+
+/**
+ * @openapi
+ * /threads/{threadId}/lock:
+ *   post:
+ *     tags: [Threads]
+ *     summary: Lock thread (author only)
+ */
+router.post("/:threadId/lock", asyncHandler(lockThread));
+
+/**
+ * @openapi
+ * /threads/{threadId}/unlock:
+ *   post:
+ *     tags: [Threads]
+ *     summary: Unlock thread (author only)
+ */
+router.post("/:threadId/unlock", asyncHandler(unlockThread));
 
 router.get(
   "/:threadId/messages",

--- a/server/src/socket/index.ts
+++ b/server/src/socket/index.ts
@@ -19,7 +19,7 @@ import {
   deleteExplorePage,
   buildExploreSections,
 } from "@features";
-import { BadRequestError, NotFoundError } from "@exceptions";
+import { BadRequestError, NotFoundError, ForbiddenError } from "@exceptions";
 import { isEmpty } from "@utils";
 import { getDistanceInMeters } from "@helpers";
 import { setPlatformNamespace, emitSocketEvent } from "./emitter";
@@ -156,6 +156,22 @@ export function initializeSocket(server: http.Server) {
             if (isEmpty(responses[0]))
               throw new NotFoundError(`Reaction or Thread not found`);
 
+            // Check if the content is in a locked thread
+            if (contentPath === EAllowedReactionTables.Message) {
+              const message = responses[0];
+              if (message && message.threadId) {
+                const lockStatus = await threadService.isThreadChainLocked(message.threadId);
+                if (lockStatus.isLocked) {
+                  throw new ForbiddenError("Cannot add reactions to messages in a locked thread");
+                }
+              }
+            } else if (contentPath === EAllowedReactionTables.Thread) {
+              const lockStatus = await threadService.isThreadChainLocked(contentId);
+              if (lockStatus.isLocked) {
+                throw new ForbiddenError("Cannot add reactions to a locked thread");
+              }
+            }
+
             const creationData = {
               contentId: reactionContentId,
               emoji: reaction,
@@ -220,6 +236,21 @@ export function initializeSocket(server: http.Server) {
               throw new NotFoundError(
                 `Content not found with provided id:${contentId}`
               );
+
+            // Check if the content is in a locked thread
+            if (contentPath === EAllowedReactionTables.Message) {
+              if (content && content.threadId) {
+                const lockStatus = await threadService.isThreadChainLocked(content.threadId);
+                if (lockStatus.isLocked) {
+                  throw new ForbiddenError("Cannot update reactions on messages in a locked thread");
+                }
+              }
+            } else if (contentPath === EAllowedReactionTables.Thread) {
+              const lockStatus = await threadService.isThreadChainLocked(contentId);
+              if (lockStatus.isLocked) {
+                throw new ForbiddenError("Cannot update reactions on a locked thread");
+              }
+            }
 
             const previousReaction = responses[1]?.[0];
 
@@ -291,6 +322,21 @@ export function initializeSocket(server: http.Server) {
               throw new NotFoundError(
                 `Content not found with provided id:${contentId}`
               );
+
+            // Check if the content is in a locked thread
+            if (contentPath === EAllowedReactionTables.Message) {
+              if (content && content.threadId) {
+                const lockStatus = await threadService.isThreadChainLocked(content.threadId);
+                if (lockStatus.isLocked) {
+                  throw new ForbiddenError("Cannot delete reactions on messages in a locked thread");
+                }
+              }
+            } else if (contentPath === EAllowedReactionTables.Thread) {
+              const lockStatus = await threadService.isThreadChainLocked(contentId);
+              if (lockStatus.isLocked) {
+                throw new ForbiddenError("Cannot delete reactions on a locked thread");
+              }
+            }
 
             const previousReaction = responses[1]?.[0];
 


### PR DESCRIPTION
Adds chat thread locking functionality, allowing authors to set threads to a view-only state, disabling new messages and reactions, with real-time UI updates and hierarchical locking.

---

[Open in Web](https://cursor.com/agents?id=bc-c1f9ac4b-3f57-4b43-9d55-8ec5be5c0a9e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c1f9ac4b-3f57-4b43-9d55-8ec5be5c0a9e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)